### PR TITLE
Improve socket and file clean up

### DIFF
--- a/pkg/tap/switch.go
+++ b/pkg/tap/switch.go
@@ -80,13 +80,13 @@ func (e *Switch) DeliverNetworkPacket(remote, local tcpip.LinkAddress, protocol 
 	}
 }
 
-func (e *Switch) Accept(ctx context.Context, conn net.Conn) {
+func (e *Switch) Accept(ctx context.Context, conn net.Conn) error {
 	log.Infof("new connection from %s to %s", conn.RemoteAddr().String(), conn.LocalAddr().String())
 	id, failed := e.connect(conn)
 	if failed {
 		log.Error("connection failed")
-		_ = conn.Close()
-		return
+		return conn.Close()
+
 	}
 
 	defer func() {
@@ -96,8 +96,9 @@ func (e *Switch) Accept(ctx context.Context, conn net.Conn) {
 	}()
 	if err := e.rx(ctx, id, conn); err != nil {
 		log.Error(errors.Wrapf(err, "cannot receive packets from %s, disconnecting", conn.RemoteAddr().String()))
-		return
+		return err
 	}
+	return nil
 }
 
 func (e *Switch) connect(conn net.Conn) (int, bool) {

--- a/pkg/virtualnetwork/qemu.go
+++ b/pkg/virtualnetwork/qemu.go
@@ -6,6 +6,5 @@ import (
 )
 
 func (n *VirtualNetwork) AcceptQemu(ctx context.Context, conn net.Conn) error {
-	n.networkSwitch.Accept(ctx, conn)
-	return nil
+	return n.networkSwitch.Accept(ctx, conn)
 }


### PR DESCRIPTION
When the VM is shut down on its own, like poweroff, gvproxy would
continue to run and be unaware it was needed anymore.  This
unfortunatgely broke subsequent attempts to run vms because the socket
and pid files persist which errors things out.

Signed-off-by: Brent Baude <bbaude@redhat.com>