### PR TITLE
Add dedicated Makefile target for gvproxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,13 @@ CONTAINER_RUNTIME ?= podman
 LDFLAGS = -ldflags '-s -w'
 
 .PHONY: build
-build:
-	go build $(LDFLAGS) -o bin/gvproxy ./cmd/gvproxy
+build: gvproxy
 	go build $(LDFLAGS) -o bin/qemu-wrapper ./cmd/qemu-wrapper
 	GOOS=linux CGO_ENABLED=0 go build $(LDFLAGS) -o bin/vm ./cmd/vm
+
+.PHONY: gvproxy
+gvproxy:
+	go build $(LDFLAGS) -o bin/gvproxy ./cmd/gvproxy
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
It avoids compiling all tools when only gvproxy is needed.

Related to #38