### PR TITLE
Remove configuration of gvproxy specific to crc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,6 @@ vm:
 clean:
 	rm -rf ./bin
 
-.PHONY: crc
-crc: build
-	scp bin/vm crc:
-
 .PHONY: vendor
 vendor:
 	go mod tidy

--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -112,6 +112,19 @@ func main() {
 		},
 		DNS: []types.Zone{
 			{
+				Name: "containers.internal.",
+				Records: []types.Record{
+					{
+						Name: "gateway",
+						IP:   net.ParseIP("192.168.127.1"),
+					},
+					{
+						Name: "host",
+						IP:   net.ParseIP("192.168.127.254"),
+					},
+				},
+			},
+			{
 				Name:      "apps-crc.testing.",
 				DefaultIP: net.ParseIP("192.168.127.2"),
 			},

--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"regexp"
 	"strconv"
 	"syscall"
 	"time"
@@ -125,11 +124,7 @@ func main() {
 				},
 			},
 			{
-				Name:      "apps-crc.testing.",
-				DefaultIP: net.ParseIP("192.168.127.2"),
-			},
-			{
-				Name: "crc.testing.",
+				Name: "crc.testing.", // still used by current version of podman machine CNI
 				Records: []types.Record{
 					{
 						Name: "gateway",
@@ -138,18 +133,6 @@ func main() {
 					{
 						Name: "host",
 						IP:   net.ParseIP("192.168.127.254"),
-					},
-					{
-						Name: "api",
-						IP:   net.ParseIP("192.168.127.2"),
-					},
-					{
-						Name: "api-int",
-						IP:   net.ParseIP("192.168.127.2"),
-					},
-					{
-						Regexp: regexp.MustCompile("crc-(.*?)-master-0"),
-						IP:     net.ParseIP("192.168.126.11"),
 					},
 				},
 			},

--- a/cmd/ssh-over-vsock/main.go
+++ b/cmd/ssh-over-vsock/main.go
@@ -13,12 +13,16 @@ import (
 var (
 	ip       string
 	port     int
+	user     string
+	key      string
 	endpoint string
 )
 
 func main() {
 	flag.StringVar(&ip, "ip", "192.168.127.2", "ip of the host")
 	flag.IntVar(&port, "port", 22, "port of the host")
+	flag.StringVar(&user, "user", "", "ssh user")
+	flag.StringVar(&key, "key", "", "ssh key")
 	flag.StringVar(&endpoint, "url", "/tmp/network.sock", "url of the daemon")
 	flag.Parse()
 
@@ -38,7 +42,7 @@ func run() error {
 		return err
 	}
 
-	client, err := newClient(conn, "core", "/home/guillaumerose/.crc/machines/crc/id_rsa")
+	client, err := newClient(conn, user, key)
 	if err != nil {
 		return err
 	}

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -47,9 +47,15 @@ var _ = Describe("dns", func() {
 		Expect(string(out)).To(ContainSubstring("Address: 209.132.183.105"))
 	})
 
-	It("should resolve gateway.crc.testing", func() {
-		out, err := sshExec("nslookup gateway.crc.testing")
+	It("should resolve gateway.containers.internal", func() {
+		out, err := sshExec("nslookup gateway.containers.internal")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(string(out)).To(ContainSubstring("Address: 192.168.127.1"))
+	})
+
+	It("should resolve host.containers.internal", func() {
+		out, err := sshExec("nslookup host.containers.internal")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(string(out)).To(ContainSubstring("Address: 192.168.127.254"))
 	})
 })


### PR DESCRIPTION
gvproxy is only used by podman, there is no need for this custom DNS records anymore.

crc uses gvisor-tap-vsock as a library and directly run the code within its own daemon.