### PR TITLE
Add script to run performance tests

### DIFF
--- a/test/performance.sh
+++ b/test/performance.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -x
+
+VM=$1
+GVPROXY_SOCKET=$2
+
+echo "Testing Internet access with a server running on the host"
+
+nohup iperf3 -s > /dev/null 2>&1 &
+serverPID=$!
+
+ssh $VM curl https://iperf.fr/download/ubuntu/libiperf.so.0_3.1.3 -o libiperf.so.0
+ssh $VM curl https://iperf.fr/download/ubuntu/iperf3_3.1.3 -o iperf3
+ssh $VM chmod +x iperf3
+
+echo "TCP: sending data"
+ssh $VM LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing
+echo "TCP: receiving data"
+ssh $VM LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -R
+
+echo "UDP: sending data"
+ssh $VM LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -u
+echo "UDP: receiving data"
+ssh $VM LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -R -u
+
+kill $serverPID
+
+echo "Testing forwarder with a server running in the VM"
+
+curl --unix-socket $GVPROXY_SOCKET http:/unix/services/forwarder/expose -X POST \
+  -d'{"local":":5201", "protocol": "udp", "remote": "192.168.127.2:5201"}'
+curl --unix-socket $GVPROXY_SOCKET http:/unix/services/forwarder/expose -X POST \
+  -d'{"local":":5201", "protocol": "tcp", "remote": "192.168.127.2:5201"}'
+
+ssh $VM LD_LIBRARY_PATH=. ./iperf3 -s > /dev/null 2>&1 &
+sleep 1
+
+echo "TCP: sending data"
+iperf3 -c 127.0.0.1
+echo "TCP: receiving data"
+iperf3 -c 127.0.0.1 -R
+
+echo "UDP: sending data"
+iperf3 -c 127.0.0.1 -u -l 9216
+echo "UDP: receiving data"
+iperf3 -c 127.0.0.1 -R -u -l 9216
+
+ssh $VM pkill iperf3
+
+curl --unix-socket $GVPROXY_SOCKET http:/unix/services/forwarder/unexpose -X POST \
+  -d'{"local":":5201", "protocol": "udp"}'
+curl --unix-socket $GVPROXY_SOCKET http:/unix/services/forwarder/unexpose -X POST \
+  -d'{"local":":5201", "protocol": "tcp"}'


### PR DESCRIPTION
Requires iperf3 on the host. Automatically install iperf3 in the VM

Report of current main with mtu=4000:

```
+ echo 'Testing Internet access with a server running on the host'
Testing Internet access with a server running on the host
+ echo 'TCP: sending data'
TCP: sending data
+ ssh crc2 LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing
+ nohup iperf3 -s
Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
no such identity: /Users/guillaumerose/.crc/machines/crc/id_ecdsa: No such file or directory
no such identity: /Users/guillaumerose/.crc/machines/crc/id_rsa: No such file or directory
Connecting to host host.crc.testing, port 5201
[  5] local 192.168.127.2 port 54766 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  34.4 MBytes   289 Mbits/sec    0   38.6 KBytes       
[  5]   1.00-2.00   sec  35.2 MBytes   295 Mbits/sec    0   38.6 KBytes       
[  5]   2.00-3.00   sec  35.3 MBytes   296 Mbits/sec    0   38.6 KBytes       
[  5]   3.00-4.00   sec  35.1 MBytes   295 Mbits/sec    0   38.6 KBytes       
[  5]   4.00-5.00   sec  34.5 MBytes   289 Mbits/sec    0   38.6 KBytes       
[  5]   5.00-6.00   sec  35.1 MBytes   295 Mbits/sec    0   38.6 KBytes       
[  5]   6.00-7.00   sec  35.5 MBytes   298 Mbits/sec    0   38.6 KBytes       
[  5]   7.00-8.00   sec  35.1 MBytes   295 Mbits/sec    0   38.6 KBytes       
[  5]   8.00-9.00   sec  36.0 MBytes   302 Mbits/sec    0   38.6 KBytes       
[  5]   9.00-10.00  sec  37.5 MBytes   315 Mbits/sec    0   38.6 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   354 MBytes   297 Mbits/sec    0             sender
[  5]   0.00-10.00  sec   354 MBytes   297 Mbits/sec                  receiver

iperf Done.
+ echo 'TCP: receiving data'
TCP: receiving data
+ ssh crc2 LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -R
Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
no such identity: /Users/guillaumerose/.crc/machines/crc/id_ecdsa: No such file or directory
no such identity: /Users/guillaumerose/.crc/machines/crc/id_rsa: No such file or directory
Connecting to host host.crc.testing, port 5201
Reverse mode, remote host host.crc.testing is sending
[  5] local 192.168.127.2 port 54770 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec   202 MBytes  1.70 Gbits/sec                  
[  5]   1.00-2.00   sec   205 MBytes  1.72 Gbits/sec                  
[  5]   2.00-3.00   sec   206 MBytes  1.73 Gbits/sec                  
[  5]   3.00-4.00   sec   206 MBytes  1.73 Gbits/sec                  
[  5]   4.00-5.00   sec   204 MBytes  1.71 Gbits/sec                  
[  5]   5.00-6.00   sec   202 MBytes  1.69 Gbits/sec                  
[  5]   6.00-7.00   sec   200 MBytes  1.67 Gbits/sec                  
[  5]   7.00-8.00   sec   185 MBytes  1.55 Gbits/sec                  
[  5]   8.00-9.00   sec   190 MBytes  1.60 Gbits/sec                  
[  5]   9.00-10.00  sec   197 MBytes  1.65 Gbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-10.00  sec  1.95 GBytes  1.68 Gbits/sec                  sender
[  5]   0.00-10.00  sec  1.95 GBytes  1.67 Gbits/sec                  receiver

iperf Done.
+ echo 'UDP: sending data'
UDP: sending data
+ ssh crc2 LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -u
Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
no such identity: /Users/guillaumerose/.crc/machines/crc/id_ecdsa: No such file or directory
no such identity: /Users/guillaumerose/.crc/machines/crc/id_rsa: No such file or directory
Connecting to host host.crc.testing, port 5201
[  5] local 192.168.127.2 port 53691 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bitrate         Total Datagrams
[  5]   0.00-1.00   sec   131 KBytes  1.07 Mbits/sec  34  
[  5]   1.00-2.00   sec   127 KBytes  1.04 Mbits/sec  33  
[  5]   2.00-3.00   sec   127 KBytes  1.04 Mbits/sec  33  
[  5]   3.00-4.00   sec   127 KBytes  1.04 Mbits/sec  33  
[  5]   4.00-5.00   sec   127 KBytes  1.04 Mbits/sec  33  
[  5]   5.00-6.00   sec   131 KBytes  1.07 Mbits/sec  34  
[  5]   6.00-7.00   sec   127 KBytes  1.04 Mbits/sec  33  
[  5]   7.00-8.00   sec   127 KBytes  1.04 Mbits/sec  33  
[  5]   8.00-9.00   sec   127 KBytes  1.04 Mbits/sec  33  
[  5]   9.00-10.00  sec   127 KBytes  1.04 Mbits/sec  33  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-10.00  sec  1.25 MBytes  1.05 Mbits/sec  0.000 ms  0/332 (0%)  sender
[  5]   0.00-10.00  sec   332 KBytes   272 Kbits/sec  0.060 ms  0/332 (0%)  receiver

iperf Done.
+ echo 'UDP: receiving data'
UDP: receiving data
+ ssh crc2 LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -R -u
Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
no such identity: /Users/guillaumerose/.crc/machines/crc/id_ecdsa: No such file or directory
no such identity: /Users/guillaumerose/.crc/machines/crc/id_rsa: No such file or directory
Connecting to host host.crc.testing, port 5201
Reverse mode, remote host host.crc.testing is sending
[  5] local 192.168.127.2 port 44390 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-1.05   sec  34.7 KBytes   270 Kbits/sec  60811897102.093 ms  24/33 (73%)  
[  5]   1.05-2.02   sec  30.8 KBytes   262 Kbits/sec  36287643241.609 ms  24/32 (75%)  
[  5]   2.02-3.00   sec  30.8 KBytes   257 Kbits/sec  21653543382.097 ms  24/32 (75%)  
[  5]   3.00-4.07   sec  34.7 KBytes   267 Kbits/sec  12113522825.624 ms  27/36 (75%)  
[  5]   4.07-5.03   sec  30.8 KBytes   262 Kbits/sec  7228374967.061 ms  24/32 (75%)  
[  5]   5.03-6.00   sec  30.8 KBytes   261 Kbits/sec  4313312107.262 ms  24/32 (75%)  
[  5]   6.00-7.08   sec  34.7 KBytes   263 Kbits/sec  2412972498.396 ms  27/36 (75%)  
[  5]   7.08-8.04   sec  30.8 KBytes   262 Kbits/sec  1439867680.037 ms  24/32 (75%)  
[  5]   8.04-9.01   sec  30.8 KBytes   263 Kbits/sec  859197084.572 ms  24/32 (75%)  
[  5]   9.01-10.09  sec  34.7 KBytes   262 Kbits/sec  480655905.609 ms  27/36 (75%)  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-10.09  sec  1.27 MBytes  1.05 Mbits/sec  0.000 ms  0/336 (0%)  sender
[  5]   0.00-10.09  sec   324 KBytes   263 Kbits/sec  480655905.609 ms  249/333 (75%)  receiver

iperf Done.
+ kill 75411
+ echo 'Testing forwarder with a server running in the VM'
Testing forwarder with a server running in the VM
+ curl --unix-socket /tmp/network.sock http:/unix/services/forwarder/expose -X POST '-d{"local":":5201", "protocol": "udp", "remote": "192.168.127.2:5201"}'
+ curl --unix-socket /tmp/network.sock http:/unix/services/forwarder/expose -X POST '-d{"local":":5201", "protocol": "tcp", "remote": "192.168.127.2:5201"}'
+ sleep 1
+ ssh crc2 LD_LIBRARY_PATH=. ./iperf3 -s
+ echo 'TCP: sending data'
TCP: sending data
+ iperf3 -c 127.0.0.1
Connecting to host 127.0.0.1, port 5201
[  5] local 127.0.0.1 port 64727 connected to 127.0.0.1 port 5201
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec   198 MBytes  1.66 Gbits/sec                  
[  5]   1.00-2.00   sec   200 MBytes  1.68 Gbits/sec                  
[  5]   2.00-3.00   sec   199 MBytes  1.67 Gbits/sec                  
[  5]   3.00-4.00   sec   182 MBytes  1.53 Gbits/sec                  
[  5]   4.00-5.00   sec   198 MBytes  1.66 Gbits/sec                  
[  5]   5.00-6.00   sec   199 MBytes  1.67 Gbits/sec                  
[  5]   6.00-7.00   sec   197 MBytes  1.65 Gbits/sec                  
[  5]   7.00-8.00   sec   194 MBytes  1.62 Gbits/sec                  
[  5]   8.00-9.00   sec   196 MBytes  1.64 Gbits/sec                  
[  5]   9.00-10.00  sec   196 MBytes  1.65 Gbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-10.00  sec  1.91 GBytes  1.64 Gbits/sec                  sender
[  5]   0.00-10.00  sec  1.91 GBytes  1.64 Gbits/sec                  receiver

iperf Done.
+ echo 'TCP: receiving data'
TCP: receiving data
+ iperf3 -c 127.0.0.1 -R
Connecting to host 127.0.0.1, port 5201
Reverse mode, remote host 127.0.0.1 is sending
[  5] local 127.0.0.1 port 64729 connected to 127.0.0.1 port 5201
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec   281 MBytes  2.36 Gbits/sec                  
[  5]   1.00-2.00   sec   275 MBytes  2.30 Gbits/sec                  
[  5]   2.00-3.00   sec   250 MBytes  2.10 Gbits/sec                  
[  5]   3.00-4.00   sec   265 MBytes  2.22 Gbits/sec                  
[  5]   4.00-5.00   sec   247 MBytes  2.08 Gbits/sec                  
[  5]   5.00-6.00   sec   242 MBytes  2.03 Gbits/sec                  
[  5]   6.00-7.00   sec   257 MBytes  2.15 Gbits/sec                  
[  5]   7.00-8.00   sec   247 MBytes  2.07 Gbits/sec                  
[  5]   8.00-9.00   sec   247 MBytes  2.08 Gbits/sec                  
[  5]   9.00-10.00  sec   259 MBytes  2.17 Gbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  2.51 GBytes  2.16 Gbits/sec    8             sender
[  5]   0.00-10.00  sec  2.51 GBytes  2.16 Gbits/sec                  receiver

iperf Done.
+ echo 'UDP: sending data'
UDP: sending data
+ iperf3 -c 127.0.0.1 -u -l 9216
Connecting to host 127.0.0.1, port 5201
[  5] local 127.0.0.1 port 55465 connected to 127.0.0.1 port 5201
[ ID] Interval           Transfer     Bitrate         Total Datagrams
[  5]   0.00-1.00   sec   135 KBytes  1.11 Mbits/sec  15  
[  5]   1.00-2.00   sec   126 KBytes  1.03 Mbits/sec  14  
[  5]   2.00-3.00   sec   126 KBytes  1.03 Mbits/sec  14  
[  5]   3.00-4.00   sec   126 KBytes  1.03 Mbits/sec  14  
[  5]   4.00-5.00   sec   135 KBytes  1.11 Mbits/sec  15  
[  5]   5.00-6.00   sec   126 KBytes  1.03 Mbits/sec  14  
[  5]   6.00-7.00   sec   126 KBytes  1.03 Mbits/sec  14  
[  5]   7.00-8.00   sec   126 KBytes  1.03 Mbits/sec  14  
[  5]   8.00-9.00   sec   126 KBytes  1.03 Mbits/sec  14  
[  5]   9.00-10.00  sec   135 KBytes  1.11 Mbits/sec  15  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-10.00  sec  1.26 MBytes  1.05 Mbits/sec  0.000 ms  0/143 (0%)  sender
[  5]   0.00-10.00  sec  1.26 MBytes  1.05 Mbits/sec  10669390.062 ms  0/143 (0%)  receiver

iperf Done.
+ echo 'UDP: receiving data'
UDP: receiving data
+ iperf3 -c 127.0.0.1 -R -u -l 9216
Connecting to host 127.0.0.1, port 5201
Reverse mode, remote host 127.0.0.1 is sending
[  5] local 127.0.0.1 port 59395 connected to 127.0.0.1 port 5201
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-1.00   sec   135 KBytes  1.11 Mbits/sec  0.038 ms  0/15 (0%)  
[  5]   1.00-2.00   sec   126 KBytes  1.03 Mbits/sec  0.049 ms  0/14 (0%)  
[  5]   2.00-3.00   sec   126 KBytes  1.03 Mbits/sec  0.062 ms  0/14 (0%)  
[  5]   3.00-4.00   sec   126 KBytes  1.03 Mbits/sec  0.076 ms  0/14 (0%)  
[  5]   4.00-5.00   sec   135 KBytes  1.11 Mbits/sec  0.062 ms  0/15 (0%)  
[  5]   5.00-6.00   sec   126 KBytes  1.03 Mbits/sec  0.053 ms  0/14 (0%)  
[  5]   6.00-7.00   sec   126 KBytes  1.03 Mbits/sec  0.051 ms  0/14 (0%)  
[  5]   7.00-8.00   sec   126 KBytes  1.03 Mbits/sec  0.056 ms  0/14 (0%)  
[  5]   8.00-9.00   sec   135 KBytes  1.11 Mbits/sec  0.054 ms  0/15 (0%)  
[  5]   9.00-10.00  sec   126 KBytes  1.03 Mbits/sec  0.053 ms  0/14 (0%)  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-10.00  sec  1.26 MBytes  1.05 Mbits/sec  0.000 ms  0/143 (0%)  sender
[  5]   0.00-10.00  sec  1.26 MBytes  1.05 Mbits/sec  0.053 ms  0/143 (0%)  receiver

iperf Done.
```
