### PR TITLE
Don’t forward UDP broadcast connection

### DIFF
--- a/pkg/services/forwarder/udp.go
+++ b/pkg/services/forwarder/udp.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
 	"gvisor.dev/gvisor/pkg/waiter"
@@ -17,7 +18,7 @@ func UDP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mute
 	return udp.NewForwarder(s, func(r *udp.ForwarderRequest) {
 		localAddress := r.ID().LocalAddress
 
-		if linkLocal().Contains(localAddress) {
+		if linkLocal().Contains(localAddress) || localAddress == header.IPv4Broadcast {
 			return
 		}
 


### PR DESCRIPTION
When performing DHCP, the forwarder tries to send to the host network DHCP 
packets. This is not wanted.
Easiest solution is to disable forwarding of broadcast traffic.