### PR TITLE
Add host search domains in the VM

### DIFF
--- a/pkg/services/dhcp/dhcp.go
+++ b/pkg/services/dhcp/dhcp.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/server4"
+	"github.com/insomniacslk/dhcp/rfc1035label"
 	log "github.com/sirupsen/logrus"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
@@ -50,6 +51,9 @@ func handler(configuration *types.Configuration, ipPool *tap.IPPool) server4.Han
 		reply.UpdateOption(dhcpv4.Option{Code: dhcpv4.OptionRouter, Value: dhcpv4.IP(net.ParseIP(configuration.GatewayIP))})
 		reply.UpdateOption(dhcpv4.Option{Code: dhcpv4.OptionDomainNameServer, Value: dhcpv4.IPs([]net.IP{net.ParseIP(configuration.GatewayIP)})})
 		reply.UpdateOption(dhcpv4.Option{Code: dhcpv4.OptionInterfaceMTU, Value: dhcpv4.Uint16(configuration.MTU)})
+		reply.UpdateOption(dhcpv4.Option{Code: dhcpv4.OptionDNSDomainSearchList, Value: &rfc1035label.Labels{
+			Labels: configuration.DNSSearchDomains,
+		}})
 
 		switch mt := m.MessageType(); mt {
 		case dhcpv4.MessageTypeDiscover:

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -28,6 +28,9 @@ type Configuration struct {
 	// Built-in DNS records that will be served by the DNS server embedded in the gateway
 	DNS []Zone
 
+	// List of search domains that will be added in all DHCP replies
+	DNSSearchDomains []string
+
 	// Port forwarding between the machine running the gateway and the virtual network.
 	Forwards map[string]string
 


### PR DESCRIPTION
Let's say I have search domain `home` on my host configured, I can do `nslookup my` on my host and it would resolv `my.home`. I need to be able to the same in the VM.
For that, the search domains need to be pushed to the VM. The built-in DNS server in gvisor-tap-vsock will do the rest!