### PR TITLE
Add support for multiple unix socket forwards over ssh

### DIFF
--- a/cmd/gvproxy/ssh_forwarder.go
+++ b/cmd/gvproxy/ssh_forwarder.go
@@ -100,8 +100,6 @@ func setupProxy(ctx context.Context, socketURI *url.URL, dest *url.URL, identity
 		return &SSHForward{}, err
 	}
 
-	logrus.Infof("Socket forward listening on: %s\n", socketURI)
-
 	connectFunc := func(bastion *sshclient.Bastion) (net.Conn, error) {
 		timeout := 5 * time.Second
 		if bastion != nil {
@@ -126,7 +124,7 @@ func setupProxy(ctx context.Context, socketURI *url.URL, dest *url.URL, identity
 		return &SSHForward{}, err
 	}
 
-	logrus.Infof("SSH Bastion connected: %s\n", dest)
+	logrus.Infof("Socket forward established: %s to %s\n", socketURI.Path, dest.Path)
 
 	return &SSHForward{listener, &bastion, socketURI}, nil
 }

--- a/test/ignition.go
+++ b/test/ignition.go
@@ -51,6 +51,13 @@ ExecStart=/usr/bin/sleep infinity
 					"sudo",
 				},
 			},
+			{
+				Name:         "root",
+				PasswordHash: &password,
+				SSHAuthorizedKeys: []SSHAuthorizedKey{
+					SSHAuthorizedKey(publicKey),
+				},
+			},
 		},
 	}
 

--- a/test/port_forwarding_test.go
+++ b/test/port_forwarding_test.go
@@ -176,11 +176,34 @@ address=/foobar/1.2.3.4
 		}).Should(Succeed())
 	})
 
-	It("should reach podman API using unix socket forwarding over ssh", func() {
+	It("should reach rootless podman API using unix socket forwarding over ssh", func() {
 		httpClient := &http.Client{
 			Transport: &http.Transport{
 				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 					return net.Dial("unix", forwardSock)
+				},
+			},
+		}
+
+		Eventually(func(g Gomega) {
+			resp, err := httpClient.Get("http://host/_ping")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			g.Expect(resp.ContentLength).To(Equal(int64(2)))
+
+			reply := make([]byte, resp.ContentLength)
+			_, err = io.ReadAtLeast(resp.Body, reply, len(reply))
+
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(string(reply)).To(Equal("OK"))
+		}).Should(Succeed())
+	})
+
+	It("should reach rootful podman API using unix socket forwarding over ssh", func() {
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return net.Dial("unix", forwardRootSock)
 				},
 			},
 		}


### PR DESCRIPTION
This PR extends the unix socket forwarding capability to support multiple socket forwards. 

Note: To keep the concurrency model simple, it utilizes multiple ssh connections, one per unix socket. Since this is all multiplexed over vsock there isn't much of an advantage to muxing over a single ssh connection anyway. 