### PR TITLE
Bump go to 1.16

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 bin/
 .git/
 *.pcap
+tmp/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/gvisor-tap-vsock
 
-go 1.15
+go 1.16
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.15.14 AS build
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS build
 WORKDIR $APP_ROOT/src
 COPY . .
 RUN make


### PR DESCRIPTION
1.16 is both used by podman and crc. It's good to upgrade now.

It will also unlock the gomega bump.