### PR TITLE
Add functionaility to expose unix/tcp over named pipe for windows

### DIFF
--- a/pkg/sshclient/npipe_unsupported.go
+++ b/pkg/sshclient/npipe_unsupported.go
@@ -9,6 +9,6 @@ import (
 	"net/url"
 )
 
-func listenNpipe(socketURI *url.URL) (net.Listener, error) {
+func ListenNpipe(socketURI *url.URL) (net.Listener, error) {
 	return nil, errors.New("named pipes are not supported by this platform")
 }

--- a/pkg/sshclient/npipe_windows.go
+++ b/pkg/sshclient/npipe_windows.go
@@ -16,7 +16,7 @@ import (
 // Allow built-in admins and system/kernel components
 const SddlDevObjSysAllAdmAll = "D:P(A;;GA;;;SY)(A;;GA;;;BA)"
 
-func listenNpipe(socketURI *url.URL) (net.Listener, error) {
+func ListenNpipe(socketURI *url.URL) (net.Listener, error) {
 	user, err := user.Current()
 	if err != nil {
 		return nil, err

--- a/pkg/sshclient/ssh_forwarder.go
+++ b/pkg/sshclient/ssh_forwarder.go
@@ -140,7 +140,7 @@ func setupProxy(ctx context.Context, socketURI *url.URL, dest *url.URL, identity
 			return &SSHForward{}, err
 		}
 	case "npipe":
-		listener, err = listenNpipe(socketURI)
+		listener, err = ListenNpipe(socketURI)
 		if err != nil {
 			return &SSHForward{}, err
 		}

--- a/pkg/types/handshake.go
+++ b/pkg/types/handshake.go
@@ -3,9 +3,10 @@ package types
 type TransportProtocol string
 
 const (
-	UDP  TransportProtocol = "udp"
-	TCP  TransportProtocol = "tcp"
-	UNIX TransportProtocol = "unix"
+	UDP   TransportProtocol = "udp"
+	TCP   TransportProtocol = "tcp"
+	UNIX  TransportProtocol = "unix"
+	NPIPE TransportProtocol = "npipe"
 )
 
 type ExposeRequest struct {


### PR DESCRIPTION
With this PR expose API can handle npipe as a protocol which is used
in windows to expose socket to named pipe.

Following is now working. (Tested with CRC)
```
\\.\pipe\crc-http - - [23/Feb/2022:10:38:20 +0530] "POST
/network/services/forwarder/expose HTTP/1.1" 200 0
INFO Listening on: \\.\pipe\crc-podman

> $Env:DOCKER_HOST = "npipe:////./pipe/crc-podman"
> .\docker.exe info
  Client:
  Context:    default
  Debug Mode: false

  Server:
  Containers: 1
  Running: 1
  Paused: 0
  Server Version: 3.4.4
  Storage Driver: overlay
  Backing Filesystem: xfs
  Supports d_type: true
```