### PR TITLE
Change ssh-port to listen on localhost only

### DIFF
--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -191,7 +191,7 @@ func main() {
 		},
 		DNSSearchDomains: searchDomains(),
 		Forwards: map[string]string{
-			fmt.Sprintf(":%d", sshPort): sshHostPort,
+			fmt.Sprintf("127.0.0.1:%d", sshPort): sshHostPort,
 		},
 		NAT: map[string]string{
 			"192.168.127.254": "127.0.0.1",


### PR DESCRIPTION
It was a bit surprising that "podman machine start" opened up an ephemeral port running sshd, listening on all interfaces!  

Is there a use case for it *not* to just listen on localhost?