### PR TITLE
test: Update redhat.com IP address

### DIFF
--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -44,7 +44,7 @@ var _ = Describe("dns", func() {
 	It("should resolve redhat.com", func() {
 		out, err := sshExec("nslookup redhat.com")
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(string(out)).To(ContainSubstring("Address: 209.132.183.105"))
+		Expect(string(out)).To(ContainSubstring("Address: 52.200.142.250"))
 	})
 
 	It("should resolve gateway.containers.internal", func() {


### PR DESCRIPTION
209.132.183.105 does not seem to be a valid IP address for redhat.com:

$ nslookup redhat.com
[...]
Non-authoritative answer:
Name:	redhat.com
Address: 52.200.142.250
Name:	redhat.com
Address: 34.235.198.240

This should fix some test failures.