### PR TITLE
always "complete" the ForwarderRequest when the connection fails

### DIFF
--- a/pkg/services/forwarder/tcp.go
+++ b/pkg/services/forwarder/tcp.go
@@ -40,11 +40,11 @@ func TCP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mute
 
 		var wq waiter.Queue
 		ep, tcpErr := r.CreateEndpoint(&wq)
+		r.Complete(false)
 		if tcpErr != nil {
 			log.Errorf("r.CreateEndpoint() = %v", tcpErr)
 			return
 		}
-		r.Complete(false)
 
 		remote := tcpproxy.DialProxy{
 			DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {


### PR DESCRIPTION
If CreateEndpoint() fails, we still need to "complete" the request in
order to free up the allocated resources. If we don't do this, then
failed requests accumulate as "inFlight", eventually overrunning the
maxInFlight limit and preventing any further TCP connections from being
made.

The bug can be triggered by executing the following within the VM:
sudo hping3 -S -p 80 www.google.com -c 20

Without this change, the gvproxy TCP stack stops responding after 10
attempts. This affects not just the hping3 execution but also all other
TCP clients, regardless of destination IP/port.

Fixes:
https://github.com/containers/gvisor-tap-vsock/issues/127
Signed-off-by: Corey Hickey <chickey@tagged.com>