### PR TITLE
test: Adding -cpu host for qemu for MacOS

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -159,7 +159,7 @@ func qemuExecutable() string {
 
 func qemuArgs() string {
 	if runtime.GOOS == "darwin" {
-		return "-machine q35,accel=hvf:tcg -smp 4"
+		return "-machine q35,accel=hvf:tcg -smp 4 -cpu host"
 	}
 	return "-cpu host"
 }


### PR DESCRIPTION
Adding the `-cpu host` option to the `qemuArgs` function for
darwin removes the warning message, "host doesn't support requested
feature: CPUID.80000001H:ECX.svm [bit 2]"