### PR TITLE
build: Build universal macOS binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-bin/
+./bin/
 capture.pcap
 tmp/
 test/qcon.log

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 TAG ?= $(shell git describe --match=NeVeRmAtCh --always --abbrev=40 --dirty)
 CONTAINER_RUNTIME ?= podman
+TOOLS_BINDIR = $(realpath tools/bin)
 
 LDFLAGS = -ldflags '-s -w'
 
@@ -41,11 +42,16 @@ image:
 	${CONTAINER_RUNTIME} build -t quay.io/crcont/gvisor-tap-vsock:$(TAG) -f images/Dockerfile .
 
 .PHONY: cross
-cross:
+cross: $(TOOLS_BINDIR)/makefat
 	GOARCH=amd64 GOOS=windows go build $(LDFLAGS) -o bin/gvproxy-windows.exe ./cmd/gvproxy
-	GOARCH=amd64 GOOS=darwin  go build $(LDFLAGS) -o bin/gvproxy-darwin ./cmd/gvproxy
+	GOARCH=amd64 GOOS=darwin  go build $(LDFLAGS) -o bin/gvproxy-darwin-amd64 ./cmd/gvproxy
 	GOARCH=arm64 GOOS=darwin  go build $(LDFLAGS) -o bin/gvproxy-darwin-arm64 ./cmd/gvproxy
 	GOARCH=amd64 GOOS=linux   go build $(LDFLAGS) -o bin/gvproxy-linux ./cmd/gvproxy
+	cd bin && $(TOOLS_BINDIR)/makefat gvproxy-darwin gvproxy-darwin-amd64 gvproxy-darwin-arm64
+
+# Needed to build macOS universal binary
+$(TOOLS_BINDIR)/makefat:
+	GOBIN=$(TOOLS_BINDIR) go install -mod=mod github.com/randall77/makefat@latest
 
 .PHONY: test-companion
 test-companion:

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,10 @@ image:
 
 .PHONY: cross
 cross:
-	GOOS=windows go build $(LDFLAGS) -o bin/gvproxy-windows.exe ./cmd/gvproxy
-	GOOS=darwin  go build $(LDFLAGS) -o bin/gvproxy-darwin ./cmd/gvproxy
-	GOOS=linux   go build $(LDFLAGS) -o bin/gvproxy-linux ./cmd/gvproxy
+	GOARCH=amd64 GOOS=windows go build $(LDFLAGS) -o bin/gvproxy-windows.exe ./cmd/gvproxy
+	GOARCH=amd64 GOOS=darwin  go build $(LDFLAGS) -o bin/gvproxy-darwin ./cmd/gvproxy
+	GOARCH=arm64 GOOS=darwin  go build $(LDFLAGS) -o bin/gvproxy-darwin-arm64 ./cmd/gvproxy
+	GOARCH=amd64 GOOS=linux   go build $(LDFLAGS) -o bin/gvproxy-linux ./cmd/gvproxy
 
 .PHONY: test-companion
 test-companion:

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -18,7 +18,7 @@ var _ = Describe("connectivity", func() {
 	It("should configure the default route", func() {
 		out, err := sshExec("ip route show")
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(string(out)).To(MatchRegexp(`default via 192\.168\.127\.1 dev (.*?) proto dhcp metric 100`))
+		Expect(string(out)).To(MatchRegexp(`default via 192\.168\.127\.1 dev (.*?) proto dhcp (src 192\.168\.127\.2 )?metric 100`))
 	})
 
 	It("should configure dns settings", func() {

--- a/tools/bin/.gitignore
+++ b/tools/bin/.gitignore
@@ -1,0 +1,1 @@
+makefat*


### PR DESCRIPTION
This PR changes two things:

  * It generates a universal binary for the gvproxy  
   For this it makes use of github.com/randall77/makefat in order to generate a gvproxy-darwin binary containing both the amd64 and arm64 binaries.
  * It fixes a test case