### PR TITLE
Allow unix sockets on windows

### DIFF
--- a/pkg/transport/listen_windows.go
+++ b/pkg/transport/listen_windows.go
@@ -25,6 +25,8 @@ func Listen(endpoint string) (net.Listener, error) {
 			VMID:      hvsock.GUIDWildcard,
 			ServiceID: svcid,
 		})
+	case "unix":
+		return net.Listen(parsed.Scheme, parsed.Path)
 	case "tcp":
 		return net.Listen("tcp", parsed.Host)
 	default:


### PR DESCRIPTION
Go allows to use unix socket in windows. Needed this as part of experiments with https://github.com/containers/podman/issues/13006 As of now I can confirm it is working for forwarding API socket from VM at least. Requires more testing with --qemu-listen over unix socket (probably with modifications of qemu).