### PR TITLE
Ignore ErrUnexpectedEOF in panicCheck and fix lint issue

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -216,12 +216,12 @@ func panicCheck(con string) (bool, error) {
 		return false, err
 	}
 
-	_, _ = file.Seek(-500, os.SEEK_END)
+	_, _ = file.Seek(-500, io.SeekEnd)
 	// Ignore seek errors (not enough content yet)
 
 	contents := make([]byte, 500)
 	_, err = io.ReadAtLeast(file, contents, len(contents))
-	if err != nil {
+	if err != nil && err != io.ErrUnexpectedEOF {
 		return false, err
 	}
 


### PR DESCRIPTION
This PR does the following,
1. Fixes the flaky test as discussed in https://github.com/containers/gvisor-tap-vsock/pull/135
2. Fixes the lint issues due to the use of deprecated package io/ioutils
