### PR TITLE
vm: Make network configuration optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 TAG ?= $(shell git describe --match=NeVeRmAtCh --always --abbrev=40 --dirty)
 CONTAINER_RUNTIME ?= podman
-TOOLS_BINDIR = $(realpath tools/bin)
-
-LDFLAGS = -ldflags '-s -w'
 
 .PHONY: build
 build: gvproxy qemu-wrapper vm
+
+TOOLS_DIR := tools
+include tools/tools.mk
+
+LDFLAGS = -ldflags '-s -w'
 
 .PHONY: gvproxy
 gvproxy:
@@ -48,10 +50,6 @@ cross: $(TOOLS_BINDIR)/makefat
 	GOARCH=arm64 GOOS=darwin  go build $(LDFLAGS) -o bin/gvproxy-darwin-arm64 ./cmd/gvproxy
 	GOARCH=amd64 GOOS=linux   go build $(LDFLAGS) -o bin/gvproxy-linux ./cmd/gvproxy
 	cd bin && $(TOOLS_BINDIR)/makefat gvproxy-darwin gvproxy-darwin-amd64 gvproxy-darwin-arm64
-
-# Needed to build macOS universal binary
-$(TOOLS_BINDIR)/makefat:
-	GOBIN=$(TOOLS_BINDIR) go install -mod=mod github.com/randall77/makefat@latest
 
 .PHONY: test-companion
 test-companion:

--- a/tools/dummy.go
+++ b/tools/dummy.go
@@ -1,0 +1,8 @@
+// This file is not meant to be built, it's just a placeholder to ensure
+// the source for the various tools that we use is properly referenced in go.mod
+// and vendored in vendor/
+package buildtools
+
+import (
+	_ "github.com/randall77/makefat"
+)

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,0 +1,5 @@
+module github.com/code-ready/crc/tools
+
+go 1.17
+
+require github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,0 +1,2 @@
+github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844 h1:GranzK4hv1/pqTIhMTXt2X8MmMOuH3hMeUR0o9SP5yc=
+github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844/go.mod h1:T1TLSfyWVBRXVGzWd0o9BI4kfoO9InEgfQe4NV3mLz8=

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -1,0 +1,10 @@
+TOOLS_BINDIR = $(realpath $(TOOLS_DIR)/bin)
+
+$(TOOLS_BINDIR)/makefat: $(TOOLS_DIR)/go.mod
+	cd $(TOOLS_DIR) && GOBIN="$(TOOLS_BINDIR)" go install github.com/randall77/makefat
+
+$(TOOLS_BINDIR)/golangci-lint: $(TOOLS_DIR)/go.mod
+	cd $(TOOLS_DIR) && GOBIN="$(TOOLS_BINDIR)" go install github.com/golangci/golangci-lint/cmd/golangci-lint
+
+$(TOOLS_BINDIR)/gomod2rpmdeps: $(TOOLS_DIR)/go.mod
+	cd $(TOOLS_DIR) && GOBIN="$(TOOLS_BINDIR)" go install github.com/cfergeau/gomod2rpmdeps/cmd/gomod2rpmdeps

--- a/tools/vendor/github.com/randall77/makefat/.gitignore
+++ b/tools/vendor/github.com/randall77/makefat/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/tools/vendor/github.com/randall77/makefat/LICENSE
+++ b/tools/vendor/github.com/randall77/makefat/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/tools/vendor/github.com/randall77/makefat/README.md
+++ b/tools/vendor/github.com/randall77/makefat/README.md
@@ -1,0 +1,8 @@
+# makefat
+A tool for making fat OSX binaries (a portable lipo)
+
+You give it some executables, it makes a fat executable from them. The fat executable will run on any architecture supported by one of the input executables.
+
+```
+makefat <output file> <input file 1> <input file 2> ...
+```

--- a/tools/vendor/github.com/randall77/makefat/makefat.go
+++ b/tools/vendor/github.com/randall77/makefat/makefat.go
@@ -1,0 +1,133 @@
+package main
+
+// makefat <output file> <input file 1> <input file 2> ...
+
+import (
+	"debug/macho"
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+const (
+	MagicFat64 = macho.MagicFat + 1 // TODO: add to stdlib (...when it works)
+
+	// Alignment wanted for each sub-file.
+	// amd64 needs 12 bits, arm64 needs 14. We choose the max of all requirements here.
+	alignBits = 14
+	align     = 1 << alignBits
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Fprintf(os.Stderr, "usage: %s <output file> <input file 1> <input file 2> ...\n", os.Args[0])
+		os.Exit(2)
+	}
+
+	// Read input files.
+	type input struct {
+		data   []byte
+		cpu    uint32
+		subcpu uint32
+		offset int64
+	}
+	var inputs []input
+	offset := int64(align)
+	for _, i := range os.Args[2:] {
+		data, err := ioutil.ReadFile(i)
+		if err != nil {
+			panic(err)
+		}
+		if len(data) < 12 {
+			panic(fmt.Sprintf("file %s too small", i))
+		}
+		// All currently supported mac archs (386,amd64,arm,arm64) are little endian.
+		magic := binary.LittleEndian.Uint32(data[0:4])
+		if magic != macho.Magic32 && magic != macho.Magic64 {
+			panic(fmt.Sprintf("input %s is not a macho file, magic=%x", i, magic))
+		}
+		cpu := binary.LittleEndian.Uint32(data[4:8])
+		subcpu := binary.LittleEndian.Uint32(data[8:12])
+		inputs = append(inputs, input{data: data, cpu: cpu, subcpu: subcpu, offset: offset})
+		offset += int64(len(data))
+		offset = (offset + align - 1) / align * align
+	}
+
+	// Decide on whether we're doing fat32 or fat64.
+	sixtyfour := false
+	if inputs[len(inputs)-1].offset >= 1<<32 || len(inputs[len(inputs)-1].data) >= 1<<32 {
+		sixtyfour = true
+		// fat64 doesn't seem to work:
+		//   - the resulting binary won't run.
+		//   - the resulting binary is parseable by lipo, but reports that the contained files are "hidden".
+		//   - the native OSX lipo can't make a fat64.
+		panic("files too large to fit into a fat binary")
+	}
+
+	// Make output file.
+	out, err := os.Create(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	err = out.Chmod(0755)
+	if err != nil {
+		panic(err)
+	}
+
+	// Build a fat_header.
+	var hdr []uint32
+	if sixtyfour {
+		hdr = append(hdr, MagicFat64)
+	} else {
+		hdr = append(hdr, macho.MagicFat)
+	}
+	hdr = append(hdr, uint32(len(inputs)))
+
+	// Build a fat_arch for each input file.
+	for _, i := range inputs {
+		hdr = append(hdr, i.cpu)
+		hdr = append(hdr, i.subcpu)
+		if sixtyfour {
+			hdr = append(hdr, uint32(i.offset>>32)) // big endian
+		}
+		hdr = append(hdr, uint32(i.offset))
+		if sixtyfour {
+			hdr = append(hdr, uint32(len(i.data)>>32)) // big endian
+		}
+		hdr = append(hdr, uint32(len(i.data)))
+		hdr = append(hdr, alignBits)
+		if sixtyfour {
+			hdr = append(hdr, 0) // reserved
+		}
+	}
+
+	// Write header.
+	// Note that the fat binary header is big-endian, regardless of the
+	// endianness of the contained files.
+	err = binary.Write(out, binary.BigEndian, hdr)
+	if err != nil {
+		panic(err)
+	}
+	offset = int64(4 * len(hdr))
+
+	// Write each contained file.
+	for _, i := range inputs {
+		if offset < i.offset {
+			_, err = out.Write(make([]byte, i.offset-offset))
+			if err != nil {
+				panic(err)
+			}
+			offset = i.offset
+		}
+		_, err := out.Write(i.data)
+		if err != nil {
+			panic(err)
+		}
+		offset += int64(len(i.data))
+	}
+	err = out.Close()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/tools/vendor/modules.txt
+++ b/tools/vendor/modules.txt
@@ -1,0 +1,3 @@
+# github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844
+## explicit; go 1.13
+github.com/randall77/makefat


### PR DESCRIPTION
Add command line option to make network configuration of the TAP interface
optional.

This allows to use create the tap device using 'native' tools, for example:
```
# nmcli connection add type tun ifname tap0 con-name tap0 mode tap
# nmcli conn up tap0 ifname tap0
```
The advantage of not doing the configuration in the 'vm' binary is that we
don't need to hardcode the name of a dhcp client and call it from go code,
we can just use native OS networking (NetworkManager, systemd-resolved,
...) and let it do its work.

There is currently no dhcp client easily available in ubi8 images, and for
the images we use in CRC, we'd prefer not to use a busybox base image, this
work helps with that.

After this change, 'vm' can be started as a systemd service:
```
[Unit] Description=gvisor-tap-vsock traffic forwarder 
BindsTo=sys-devices-virtual-net-tap0.device 
After=sys-devices-virtual-net-tap0.device

[Service] Restart=on-success TimeoutStopSec=70 
ExecStart=/usr/bin/gvisor-tap-vsock-forwarder -preexisting

[Install] WantedBy=default.target
```