### PR TITLE
go.mod: Update gvisor to latest upstream version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,6 @@ require (
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
-	gvisor.dev/gvisor v0.0.0-20220722234115-e3e6499abbba
+	gvisor.dev/gvisor v0.0.0-20220908032458-edc830a43ba6
 	inet.af/tcpproxy v0.0.0-20220326234310-be3ee21c9fa0
 )

--- a/go.sum
+++ b/go.sum
@@ -806,8 +806,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
-gvisor.dev/gvisor v0.0.0-20220722234115-e3e6499abbba h1:XCAVnJl9nmC1CC4g5ycIXDeqiLHiz3n/5zH1ZKLOxDM=
-gvisor.dev/gvisor v0.0.0-20220722234115-e3e6499abbba/go.mod h1:TIvkJD0sxe8pIob3p6T8IzxXunlp6yfgktvTNp+DGNM=
+gvisor.dev/gvisor v0.0.0-20220908032458-edc830a43ba6 h1:Aq4piePGzmo0ij3yfseJ0rj9W8jxSJgRfiA9QMWngdA=
+gvisor.dev/gvisor v0.0.0-20220908032458-edc830a43ba6/go.mod h1:TIvkJD0sxe8pIob3p6T8IzxXunlp6yfgktvTNp+DGNM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/vendor/gvisor.dev/gvisor/pkg/atomicbitops/atomicbitops_arm64.go
+++ b/vendor/gvisor.dev/gvisor/pkg/atomicbitops/atomicbitops_arm64.go
@@ -17,6 +17,24 @@
 
 package atomicbitops
 
-import "gvisor.dev/gvisor/pkg/cpuid"
+import (
+	"runtime"
 
-var arm64HasATOMICS = cpuid.HostFeatureSet().HasFeature(cpuid.ARM64FeatureATOMICS)
+	"golang.org/x/sys/cpu"
+	"gvisor.dev/gvisor/pkg/cpuid"
+)
+
+var arm64HasATOMICS bool
+
+func init() {
+	// The gvisor cpuid package only works on Linux.
+	// For all other operating systems, use Go's x/sys/cpu package
+	// to get the one bit we care about here.
+	//
+	// See https://github.com/google/gvisor/issues/7849.
+	if runtime.GOOS == "linux" {
+		arm64HasATOMICS = cpuid.HostFeatureSet().HasFeature(cpuid.ARM64FeatureATOMICS)
+	} else {
+		arm64HasATOMICS = cpu.ARM64.HasATOMICS
+	}
+}

--- a/vendor/gvisor.dev/gvisor/pkg/bufferv2/buffer.go
+++ b/vendor/gvisor.dev/gvisor/pkg/bufferv2/buffer.go
@@ -571,6 +571,11 @@ func (br *BufferReader) Close() {
 	br.b.Release()
 }
 
+// Len returns the number of bytes in the unread portion of the buffer.
+func (br *BufferReader) Len() int {
+	return int(br.b.Size())
+}
+
 // Range specifies a range of buffer.
 type Range struct {
 	begin int

--- a/vendor/gvisor.dev/gvisor/pkg/bufferv2/view.go
+++ b/vendor/gvisor.dev/gvisor/pkg/bufferv2/view.go
@@ -161,6 +161,16 @@ func (v *View) AsSlice() []byte {
 	return v.chunk.data[v.read:v.write]
 }
 
+// ToSlice returns an owned copy of the data in this view.
+func (v *View) ToSlice() []byte {
+	if v.Size() == 0 {
+		return nil
+	}
+	s := make([]byte, v.Size())
+	copy(s, v.AsSlice())
+	return s
+}
+
 // AvailableSize returns the number of bytes available for writing.
 func (v *View) AvailableSize() int {
 	if v == nil {

--- a/vendor/gvisor.dev/gvisor/pkg/cpuid/native_arm64.go
+++ b/vendor/gvisor.dev/gvisor/pkg/cpuid/native_arm64.go
@@ -20,6 +20,7 @@ package cpuid
 import (
 	"encoding/binary"
 	"io/ioutil"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -46,6 +47,11 @@ func (fs FeatureSet) Fixed() FeatureSet {
 // Must run before syscall filter installation. This value is used to create
 // the fake /proc/cpuinfo from a FeatureSet.
 func initCPUInfo() {
+	if runtime.GOOS != "linux" {
+		// Don't try to read Linux-specific /proc files or
+		// warn about them not existing.
+		return
+	}
 	cpuinfob, err := ioutil.ReadFile("/proc/cpuinfo")
 	if err != nil {
 		// Leave everything at 0, nothing can be done.
@@ -172,6 +178,11 @@ func initCPUInfo() {
 //	0000440                   15      140734614619529
 //	0000460                    0                    0
 func initHwCap() {
+	if runtime.GOOS != "linux" {
+		// Don't try to read Linux-specific /proc files or
+		// warn about them not existing.
+		return
+	}
 	auxv, err := ioutil.ReadFile("/proc/self/auxv")
 	if err != nil {
 		log.Warningf("Could not read /proc/self/auxv: %v", err)

--- a/vendor/gvisor.dev/gvisor/pkg/gohacks/gohacks_unsafe.go
+++ b/vendor/gvisor.dev/gvisor/pkg/gohacks/gohacks_unsafe.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.13 && !go1.20
-// +build go1.13,!go1.20
+//go:build go1.13 && !go1.21
+// +build go1.13,!go1.21
 
 // //go:linkname directives type-checked by checklinkname. Any other
 // non-linkname assumptions outside the Go 1 compatibility guarantee should

--- a/vendor/gvisor.dev/gvisor/pkg/goid/goid.go
+++ b/vendor/gvisor.dev/gvisor/pkg/goid/goid.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.12 && !go1.20
-// +build go1.12,!go1.20
+//go:build go1.12 && !go1.21
+// +build go1.12,!go1.21
 
 // Check type signatures when updating Go version.
 

--- a/vendor/gvisor.dev/gvisor/pkg/refsvfs2/refs_map.go
+++ b/vendor/gvisor.dev/gvisor/pkg/refsvfs2/refs_map.go
@@ -50,7 +50,8 @@ func init() {
 // LeakCheckEnabled returns whether leak checking is enabled. The following
 // functions should only be called if it returns true.
 func LeakCheckEnabled() bool {
-	return refs_vfs1.GetLeakMode() != refs_vfs1.NoLeakChecking
+	mode := refs_vfs1.GetLeakMode()
+	return mode != refs_vfs1.NoLeakChecking && mode != refs_vfs1.UninitializedLeakChecking
 }
 
 // leakCheckPanicEnabled returns whether DoLeakCheck() should panic when leaks

--- a/vendor/gvisor.dev/gvisor/pkg/sync/mutex_unsafe.go
+++ b/vendor/gvisor.dev/gvisor/pkg/sync/mutex_unsafe.go
@@ -3,8 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build go1.13 && !go1.20
-// +build go1.13,!go1.20
+//go:build go1.13 && !go1.21
+// +build go1.13,!go1.21
 
 // When updating the build constraint (above), check that syncMutex matches the
 // standard library sync.Mutex definition.

--- a/vendor/gvisor.dev/gvisor/pkg/sync/runtime_amd64.go
+++ b/vendor/gvisor.dev/gvisor/pkg/sync/runtime_amd64.go
@@ -3,8 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build amd64 && go1.8 && !go1.20 && !goexperiment.staticlockranking
-// +build amd64,go1.8,!go1.20,!goexperiment.staticlockranking
+//go:build amd64 && go1.8 && !go1.21 && !goexperiment.staticlockranking
+// +build amd64,go1.8,!go1.21,!goexperiment.staticlockranking
 
 package sync
 

--- a/vendor/gvisor.dev/gvisor/pkg/sync/runtime_amd64.s
+++ b/vendor/gvisor.dev/gvisor/pkg/sync/runtime_amd64.s
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build amd64 && go1.14 && !go1.20 && !goexperiment.staticlockranking
-// +build amd64,go1.14,!go1.20,!goexperiment.staticlockranking
+//go:build amd64 && go1.14 && !go1.21 && !goexperiment.staticlockranking
+// +build amd64,go1.14,!go1.21,!goexperiment.staticlockranking
 
 #include "textflag.h"
 

--- a/vendor/gvisor.dev/gvisor/pkg/sync/runtime_unsafe.go
+++ b/vendor/gvisor.dev/gvisor/pkg/sync/runtime_unsafe.go
@@ -3,8 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build go1.13 && !go1.20
-// +build go1.13,!go1.20
+//go:build go1.13 && !go1.21
+// +build go1.13,!go1.21
 
 // //go:linkname directives type-checked by checklinkname. Any other
 // non-linkname assumptions outside the Go 1 compatibility guarantee should

--- a/vendor/gvisor.dev/gvisor/pkg/tcpip/adapters/gonet/gonet.go
+++ b/vendor/gvisor.dev/gvisor/pkg/tcpip/adapters/gonet/gonet.go
@@ -47,10 +47,11 @@ func (e *timeoutError) Temporary() bool { return true }
 // A TCPListener is a wrapper around a TCP tcpip.Endpoint that implements
 // net.Listener.
 type TCPListener struct {
-	stack  *stack.Stack
-	ep     tcpip.Endpoint
-	wq     *waiter.Queue
-	cancel chan struct{}
+	stack      *stack.Stack
+	ep         tcpip.Endpoint
+	wq         *waiter.Queue
+	cancelOnce sync.Once
+	cancel     chan struct{}
 }
 
 // NewTCPListener creates a new TCPListener from a listening tcpip.Endpoint.
@@ -112,7 +113,9 @@ func (l *TCPListener) Close() error {
 // Shutdown stops the HTTP server.
 func (l *TCPListener) Shutdown() {
 	l.ep.Shutdown(tcpip.ShutdownWrite | tcpip.ShutdownRead)
-	close(l.cancel) // broadcast cancellation
+	l.cancelOnce.Do(func() {
+		close(l.cancel) // broadcast cancellation
+	})
 }
 
 // Addr implements net.Listener.Addr.

--- a/vendor/gvisor.dev/gvisor/pkg/tcpip/link/sniffer/sniffer.go
+++ b/vendor/gvisor.dev/gvisor/pkg/tcpip/link/sniffer/sniffer.go
@@ -55,11 +55,14 @@ var _ stack.GSOEndpoint = (*endpoint)(nil)
 var _ stack.LinkEndpoint = (*endpoint)(nil)
 var _ stack.NetworkDispatcher = (*endpoint)(nil)
 
-type direction int
+// A Direction indicates whether the packing is being sent or received.
+type Direction int
 
 const (
-	directionSend = iota
-	directionRecv
+	// DirectionSend indicates a sent packet.
+	DirectionSend = iota
+	// DirectionRecv indicates a received packet.
+	DirectionRecv
 )
 
 // New creates a new sniffer link-layer endpoint. It wraps around another
@@ -92,7 +95,7 @@ func writePCAPHeader(w io.Writer, maxLen uint32) error {
 	if err != nil {
 		return err
 	}
-	return binary.Write(w, binary.BigEndian, pcapHeader{
+	return binary.Write(w, binary.LittleEndian, pcapHeader{
 		// From https://wiki.wireshark.org/Development/LibpcapFileFormat
 		MagicNumber: 0xa1b2c3d4,
 
@@ -131,14 +134,14 @@ func NewWithWriter(lower stack.LinkEndpoint, writer io.Writer, snapLen uint32) (
 // called by the link-layer endpoint being wrapped when a packet arrives, and
 // logs the packet before forwarding to the actual dispatcher.
 func (e *endpoint) DeliverNetworkPacket(protocol tcpip.NetworkProtocolNumber, pkt *stack.PacketBuffer) {
-	e.dumpPacket(directionRecv, protocol, pkt)
+	e.dumpPacket(DirectionRecv, protocol, pkt)
 	e.Endpoint.DeliverNetworkPacket(protocol, pkt)
 }
 
-func (e *endpoint) dumpPacket(dir direction, protocol tcpip.NetworkProtocolNumber, pkt *stack.PacketBuffer) {
+func (e *endpoint) dumpPacket(dir Direction, protocol tcpip.NetworkProtocolNumber, pkt *stack.PacketBuffer) {
 	writer := e.writer
 	if writer == nil && LogPackets.Load() == 1 {
-		logPacket(e.logPrefix, dir, protocol, pkt)
+		LogPacket(e.logPrefix, dir, protocol, pkt)
 	}
 	if writer != nil && LogPacketsToPCAP.Load() == 1 {
 		packet := pcapPacket{
@@ -161,12 +164,13 @@ func (e *endpoint) dumpPacket(dir direction, protocol tcpip.NetworkProtocolNumbe
 // forwards the request to the lower endpoint.
 func (e *endpoint) WritePackets(pkts stack.PacketBufferList) (int, tcpip.Error) {
 	for _, pkt := range pkts.AsSlice() {
-		e.dumpPacket(directionSend, pkt.NetworkProtocolNumber, pkt)
+		e.dumpPacket(DirectionSend, pkt.NetworkProtocolNumber, pkt)
 	}
 	return e.Endpoint.WritePackets(pkts)
 }
 
-func logPacket(prefix string, dir direction, protocol tcpip.NetworkProtocolNumber, pkt *stack.PacketBuffer) {
+// LogPacket logs a packet to stdout.
+func LogPacket(prefix string, dir Direction, protocol tcpip.NetworkProtocolNumber, pkt *stack.PacketBuffer) {
 	// Figure out the network layer info.
 	var transProto uint8
 	src := tcpip.Address("unknown")
@@ -178,25 +182,15 @@ func logPacket(prefix string, dir direction, protocol tcpip.NetworkProtocolNumbe
 
 	var directionPrefix string
 	switch dir {
-	case directionSend:
+	case DirectionSend:
 		directionPrefix = "send"
-	case directionRecv:
+	case DirectionRecv:
 		directionPrefix = "recv"
 	default:
 		panic(fmt.Sprintf("unrecognized direction: %d", dir))
 	}
 
-	// Clone the packet buffer to not modify the original.
-	//
-	// We don't clone the original packet buffer so that the new packet buffer
-	// does not have any of its headers set.
-	//
-	// We trim the link headers from the cloned buffer as the sniffer doesn't
-	// handle link headers.
-	buf := pkt.ToBuffer()
-	buf.TrimFront(int64(len(pkt.VirtioNetHeader().Slice())))
-	buf.TrimFront(int64(len(pkt.LinkHeader().Slice())))
-	pkt = stack.NewPacketBuffer(stack.PacketBufferOptions{Payload: buf})
+	pkt = trimmedClone(pkt)
 	defer pkt.DecRef()
 	switch protocol {
 	case header.IPv4ProtocolNumber:
@@ -382,4 +376,18 @@ func logPacket(prefix string, dir direction, protocol tcpip.NetworkProtocolNumbe
 	}
 
 	log.Infof("%s%s %s %s:%d -> %s:%d len:%d id:%04x %s", prefix, directionPrefix, transName, src, srcPort, dst, dstPort, size, id, details)
+}
+
+// trimmedClone clones the packet buffer to not modify the original. It trims
+// anything before the network header.
+func trimmedClone(pkt *stack.PacketBuffer) *stack.PacketBuffer {
+	// We don't clone the original packet buffer so that the new packet buffer
+	// does not have any of its headers set.
+	//
+	// We trim the link headers from the cloned buffer as the sniffer doesn't
+	// handle link headers.
+	buf := pkt.ToBuffer()
+	buf.TrimFront(int64(len(pkt.VirtioNetHeader().Slice())))
+	buf.TrimFront(int64(len(pkt.LinkHeader().Slice())))
+	return stack.NewPacketBuffer(stack.PacketBufferOptions{Payload: buf})
 }

--- a/vendor/gvisor.dev/gvisor/pkg/tcpip/network/internal/fragmentation/fragmentation.go
+++ b/vendor/gvisor.dev/gvisor/pkg/tcpip/network/internal/fragmentation/fragmentation.go
@@ -175,6 +175,10 @@ func (f *Fragmentation) Process(
 	}
 
 	f.mu.Lock()
+	if f.reassemblers == nil {
+		return nil, 0, false, fmt.Errorf("Release() called before fragmentation processing could finish")
+	}
+
 	r, ok := f.reassemblers[id]
 	if !ok {
 		r = newReassembler(id, f.clock)

--- a/vendor/gvisor.dev/gvisor/pkg/tcpip/stack/neighbor_entry.go
+++ b/vendor/gvisor.dev/gvisor/pkg/tcpip/stack/neighbor_entry.go
@@ -34,7 +34,7 @@ type NeighborEntry struct {
 	Addr      tcpip.Address
 	LinkAddr  tcpip.LinkAddress
 	State     NeighborState
-	UpdatedAt time.Time
+	UpdatedAt tcpip.MonotonicTime
 }
 
 // NeighborState defines the state of a NeighborEntry within the Neighbor
@@ -141,7 +141,7 @@ func newStaticNeighborEntry(cache *neighborCache, addr tcpip.Address, linkAddr t
 		Addr:      addr,
 		LinkAddr:  linkAddr,
 		State:     Static,
-		UpdatedAt: cache.nic.stack.clock.Now(),
+		UpdatedAt: cache.nic.stack.clock.NowMonotonic(),
 	}
 	n := &neighborEntry{
 		cache:    cache,
@@ -230,7 +230,7 @@ func (e *neighborEntry) cancelTimerLocked() {
 //
 // Precondition: e.mu MUST be locked.
 func (e *neighborEntry) removeLocked() {
-	e.mu.neigh.UpdatedAt = e.cache.nic.stack.clock.Now()
+	e.mu.neigh.UpdatedAt = e.cache.nic.stack.clock.NowMonotonic()
 	e.dispatchRemoveEventLocked()
 	e.cancelTimerLocked()
 	// TODO(https://gvisor.dev/issues/5583): test the case where this function is
@@ -252,7 +252,7 @@ func (e *neighborEntry) setStateLocked(next NeighborState) {
 
 	prev := e.mu.neigh.State
 	e.mu.neigh.State = next
-	e.mu.neigh.UpdatedAt = e.cache.nic.stack.clock.Now()
+	e.mu.neigh.UpdatedAt = e.cache.nic.stack.clock.NowMonotonic()
 	config := e.nudState.Config()
 
 	switch next {
@@ -360,7 +360,7 @@ func (e *neighborEntry) handlePacketQueuedLocked(localAddr tcpip.Address) {
 	case Unknown, Unreachable:
 		prev := e.mu.neigh.State
 		e.mu.neigh.State = Incomplete
-		e.mu.neigh.UpdatedAt = e.cache.nic.stack.clock.Now()
+		e.mu.neigh.UpdatedAt = e.cache.nic.stack.clock.NowMonotonic()
 
 		switch prev {
 		case Unknown:

--- a/vendor/gvisor.dev/gvisor/pkg/tcpip/stack/nud.go
+++ b/vendor/gvisor.dev/gvisor/pkg/tcpip/stack/nud.go
@@ -329,7 +329,7 @@ type NUDState struct {
 		// the algorithm defined in RFC 4861 section 6.3.2.
 		reachableTime time.Duration
 
-		expiration            time.Time
+		expiration            tcpip.MonotonicTime
 		prevBaseReachableTime time.Duration
 		prevMinRandomFactor   float32
 		prevMaxRandomFactor   float32
@@ -369,7 +369,7 @@ func (s *NUDState) ReachableTime() time.Duration {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.clock.Now().After(s.mu.expiration) ||
+	if s.clock.NowMonotonic().After(s.mu.expiration) ||
 		s.mu.config.BaseReachableTime != s.mu.prevBaseReachableTime ||
 		s.mu.config.MinRandomFactor != s.mu.prevMinRandomFactor ||
 		s.mu.config.MaxRandomFactor != s.mu.prevMaxRandomFactor {
@@ -418,5 +418,5 @@ func (s *NUDState) recomputeReachableTimeLocked() {
 		s.mu.reachableTime = time.Duration(reachableTime)
 	}
 
-	s.mu.expiration = s.clock.Now().Add(2 * time.Hour)
+	s.mu.expiration = s.clock.NowMonotonic().Add(2 * time.Hour)
 }

--- a/vendor/gvisor.dev/gvisor/pkg/tcpip/tcpip.go
+++ b/vendor/gvisor.dev/gvisor/pkg/tcpip/tcpip.go
@@ -45,8 +45,13 @@ import (
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
-// Using header.IPv4AddressSize would cause an import cycle.
-const ipv4AddressSize = 4
+// Using the header package here would cause an import cycle.
+const (
+	ipv4AddressSize    = 4
+	ipv4ProtocolNumber = 0x0800
+	ipv6AddressSize    = 16
+	ipv6ProtocolNumber = 0x86dd
+)
 
 // Errors related to Subnet
 var (

--- a/vendor/gvisor.dev/gvisor/pkg/tcpip/transport/internal/network/endpoint.go
+++ b/vendor/gvisor.dev/gvisor/pkg/tcpip/transport/internal/network/endpoint.go
@@ -915,7 +915,7 @@ func (e *Endpoint) SetSockOpt(opt tcpip.SettableSocketOption) tcpip.Error {
 		e.multicastAddr = addr
 
 	case *tcpip.AddMembershipOption:
-		if !header.IsV4MulticastAddress(v.MulticastAddr) && !header.IsV6MulticastAddress(v.MulticastAddr) {
+		if !(header.IsV4MulticastAddress(v.MulticastAddr) && e.netProto == header.IPv4ProtocolNumber) && !(header.IsV6MulticastAddress(v.MulticastAddr) && e.netProto == header.IPv6ProtocolNumber) {
 			return &tcpip.ErrInvalidOptionValue{}
 		}
 

--- a/vendor/gvisor.dev/gvisor/pkg/tcpip/transport/tcp/connect.go
+++ b/vendor/gvisor.dev/gvisor/pkg/tcpip/transport/tcp/connect.go
@@ -130,7 +130,6 @@ func maybeFailTimerHandler(e *endpoint, f func() tcpip.Error) func() {
 			e.lastError = err
 			e.lastErrorMu.Unlock()
 			e.hardError = err
-			e.stack.Stats().TCP.CurrentConnected.Decrement()
 			e.cleanupLocked()
 			e.setEndpointState(StateError)
 			e.mu.Unlock()
@@ -1050,7 +1049,6 @@ func (e *endpoint) transitionToStateCloseLocked() {
 	}
 
 	if s.connected() {
-		e.stack.Stats().TCP.CurrentConnected.Decrement()
 		e.stack.Stats().TCP.EstablishedClosed.Increment()
 	}
 

--- a/vendor/gvisor.dev/gvisor/pkg/tcpip/transport/tcp/dispatcher.go
+++ b/vendor/gvisor.dev/gvisor/pkg/tcpip/transport/tcp/dispatcher.go
@@ -196,7 +196,6 @@ func (p *processor) handleConnected(ep *endpoint) {
 		fallthrough
 	case ep.EndpointState() == StateClose:
 		ep.mu.Unlock()
-		ep.stack.Stats().TCP.CurrentConnected.Decrement()
 		ep.drainClosingSegmentQueue()
 		ep.waiterQueue.Notify(waiter.EventHUp | waiter.EventErr | waiter.ReadableEvents | waiter.WritableEvents)
 		return

--- a/vendor/gvisor.dev/gvisor/pkg/tcpip/transport/tcp/endpoint.go
+++ b/vendor/gvisor.dev/gvisor/pkg/tcpip/transport/tcp/endpoint.go
@@ -731,6 +731,9 @@ func (e *endpoint) setEndpointState(state EndpointState) {
 		if oldstate == StateCloseWait || oldstate == StateEstablished {
 			e.stack.Stats().TCP.EstablishedResets.Increment()
 		}
+		if oldstate.connected() {
+			e.stack.Stats().TCP.CurrentConnected.Decrement()
+		}
 		fallthrough
 	default:
 		if oldstate == StateEstablished {
@@ -977,7 +980,6 @@ func (e *endpoint) Abort() {
 	// Reset all connected endpoints.
 	switch state := e.EndpointState(); {
 	case state.connected():
-		e.stack.Stats().TCP.CurrentConnected.Decrement()
 		e.resetConnectionLocked(&tcpip.ErrAborted{})
 		return
 	}

--- a/vendor/gvisor.dev/gvisor/pkg/tcpip/transport/tcp/segment.go
+++ b/vendor/gvisor.dev/gvisor/pkg/tcpip/transport/tcp/segment.go
@@ -19,6 +19,7 @@ import (
 	"io"
 
 	"gvisor.dev/gvisor/pkg/bufferv2"
+	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/seqnum"
@@ -38,6 +39,12 @@ const (
 	recvQ queueFlags = 1 << iota
 	sendQ
 )
+
+var segmentPool = sync.Pool{
+	New: func() interface{} {
+		return &segment{}
+	},
+}
 
 // segment represents a TCP segment. It holds the payload and parsed TCP segment
 // information, and can be added to intrusive lists.
@@ -99,21 +106,19 @@ func newIncomingSegment(id stack.TransportEndpointID, clock tcpip.Clock, pkt *st
 		return nil, fmt.Errorf("header data offset does not respect size constraints: %d < offset < %d, got offset=%d", header.TCPMinimumSize, len(hdr), hdr.DataOffset())
 	}
 
-	s := &segment{
-		id:             id,
-		options:        hdr[header.TCPMinimumSize:],
-		parsedOptions:  header.ParseTCPOptions(hdr[header.TCPMinimumSize:]),
-		sequenceNumber: seqnum.Value(hdr.SequenceNumber()),
-		ackNumber:      seqnum.Value(hdr.AckNumber()),
-		flags:          hdr.Flags(),
-		window:         seqnum.Size(hdr.WindowSize()),
-		rcvdTime:       clock.NowMonotonic(),
-		dataMemSize:    pkt.MemSize(),
-		pkt:            pkt,
-		csumValid:      csumValid,
-	}
+	s := newSegment()
+	s.id = id
+	s.options = hdr[header.TCPMinimumSize:]
+	s.parsedOptions = header.ParseTCPOptions(hdr[header.TCPMinimumSize:])
+	s.sequenceNumber = seqnum.Value(hdr.SequenceNumber())
+	s.ackNumber = seqnum.Value(hdr.AckNumber())
+	s.flags = hdr.Flags()
+	s.window = seqnum.Size(hdr.WindowSize())
+	s.rcvdTime = clock.NowMonotonic()
+	s.dataMemSize = pkt.MemSize()
+	s.pkt = pkt
 	pkt.IncRef()
-	s.InitRefs()
+	s.csumValid = csumValid
 
 	if !s.pkt.RXTransportChecksumValidated {
 		s.csum = csum
@@ -122,10 +127,8 @@ func newIncomingSegment(id stack.TransportEndpointID, clock tcpip.Clock, pkt *st
 }
 
 func newOutgoingSegment(id stack.TransportEndpointID, clock tcpip.Clock, buf bufferv2.Buffer) *segment {
-	s := &segment{
-		id: id,
-	}
-	s.InitRefs()
+	s := newSegment()
+	s.id = id
 	s.rcvdTime = clock.NowMonotonic()
 	s.pkt = stack.NewPacketBuffer(stack.PacketBufferOptions{Payload: buf})
 	s.dataMemSize = s.pkt.MemSize()
@@ -133,22 +136,27 @@ func newOutgoingSegment(id stack.TransportEndpointID, clock tcpip.Clock, buf buf
 }
 
 func (s *segment) clone() *segment {
-	t := &segment{
-		id:             s.id,
-		sequenceNumber: s.sequenceNumber,
-		ackNumber:      s.ackNumber,
-		flags:          s.flags,
-		window:         s.window,
-		rcvdTime:       s.rcvdTime,
-		xmitTime:       s.xmitTime,
-		xmitCount:      s.xmitCount,
-		ep:             s.ep,
-		qFlags:         s.qFlags,
-		dataMemSize:    s.dataMemSize,
-	}
-	t.InitRefs()
+	t := newSegment()
+	t.id = s.id
+	t.sequenceNumber = s.sequenceNumber
+	t.ackNumber = s.ackNumber
+	t.flags = s.flags
+	t.window = s.window
+	t.rcvdTime = s.rcvdTime
+	t.xmitTime = s.xmitTime
+	t.xmitCount = s.xmitCount
+	t.ep = s.ep
+	t.qFlags = s.qFlags
+	t.dataMemSize = s.dataMemSize
 	t.pkt = s.pkt.Clone()
 	return t
+}
+
+func newSegment() *segment {
+	s := segmentPool.Get().(*segment)
+	*s = segment{}
+	s.InitRefs()
+	return s
 }
 
 // merge merges data in oth and clears oth.
@@ -176,8 +184,6 @@ func (s *segment) setOwner(ep *endpoint, qFlags queueFlags) {
 
 func (s *segment) DecRef() {
 	s.segmentRefs.DecRef(func() {
-		defer s.pkt.DecRef()
-		s.pkt = nil
 		if s.ep != nil {
 			switch s.qFlags {
 			case recvQ:
@@ -188,6 +194,9 @@ func (s *segment) DecRef() {
 				panic(fmt.Sprintf("unexpected queue flag %b set for segment", s.qFlags))
 			}
 		}
+		s.pkt.DecRef()
+		s.pkt = nil
+		segmentPool.Put(s)
 	})
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -191,7 +191,7 @@ golang.org/x/tools/internal/typesinternal
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v3 v3.0.1
 gopkg.in/yaml.v3
-# gvisor.dev/gvisor v0.0.0-20220722234115-e3e6499abbba
+# gvisor.dev/gvisor v0.0.0-20220908032458-edc830a43ba6
 ## explicit
 gvisor.dev/gvisor/pkg/atomicbitops
 gvisor.dev/gvisor/pkg/bits


### PR DESCRIPTION
On M1, we need https://github.com/google/gvisor/commit/801f45ab4b3 to
avoid warnings at startup:

W0907 11:20:23.957462   17449 native_arm64.go:52] Could not read /proc/cpuinfo: open /proc/cpuinfo: no such file or directory
W0907 11:20:23.957629   17449 native_arm64.go:177] Could not read /proc/self/auxv: open /proc/self/auxv: no such file or directory