### PR TITLE
Option to build gvproxy as Windows GUI (background) app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ vm:
 win-sshproxy:
 	GOOS=windows go build -ldflags -H=windowsgui -o bin/win-sshproxy.exe ./cmd/win-sshproxy
 
+# gvproxy for windows is compiled as a windows GUI to support backgrounding
+.PHONY: win-gvproxy
+win-gvproxy:
+	GOOS=windows go build -ldflags -H=windowsgui -o bin/gvproxy.exe ./cmd/gvproxy
+
 .PHONY: clean
 clean:
 	rm -rf ./bin


### PR DESCRIPTION
Additional preconfigured build option to use when building for Windows platform. gvproxy will be built as a Windows GUI application.

Using new build configuration to not break potential existent workloads, which are utilizing current console app build.

This is needed to fix https://github.com/containers/podman/pull/16872#issuecomment-1356241778

Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>