### PR TITLE
container: Use golang 1.18 build image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18 AS build
 WORKDIR $APP_ROOT/src
 COPY . .
 RUN make


### PR DESCRIPTION
1.16 is no longer supported upstream, and gvisor-tap-vsock fails to
build with it