### PR TITLE
Document Qemu 7.2.0 QAPI changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ With gvproxy and the VM discussing on a unix socket:
 (terminal 2) $ bin/qemu-wrapper /tmp/qemu.sock qemu-system-x86_64 (all your qemu options) -netdev socket,id=vlan,fd=3 -device virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee
 ```
 
+Starting from Qemu version 7.2.0 it is possible to run w/o a wrapper:
+```
+(terminal 1) $ bin/gvproxy -debug -listen unix:///tmp/network.sock -listen-qemu unix:///tmp/qemu.sock
+(terminal 2) $ qemu-system-x86_64 (all your qemu options) -netdev stream,id=vlan,addr.type=unix,addr.path=/tmp/qemu.sock -device virtio-net-pci,netdev=vlan,mac=5a:94:ef:e4:0c:ee
+```
+
 ## Run with User Mode Linux
 
 ```


### PR DESCRIPTION
Starting from version 7.2.0 there is no need to use `qemu-wrapper`.

New options described here: https://github.com/qemu/qemu/blob/7c9236d6d61f30583d5d860097d88dbf0fe487bf/qemu-options.hx#L2773

Now it is also possible to use Unix domain socket on Windows OS (as FD approach is not supported on that OS), but as there was no Windows documentation prior to this moment (even for TCP sockets) it is not provided.

Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>