### PR TITLE
Support for using multiple protocols

### DIFF
--- a/pkg/tap/connection.go
+++ b/pkg/tap/connection.go
@@ -1,0 +1,10 @@
+package tap
+
+import (
+	"net"
+)
+
+type protocolConn struct {
+	net.Conn
+	protocolImpl protocol
+}

--- a/pkg/tap/switch.go
+++ b/pkg/tap/switch.go
@@ -36,7 +36,7 @@ type Switch struct {
 	maxTransmissionUnit int
 
 	nextConnID int
-	conns      map[int]net.Conn
+	conns      map[int]protocolConn
 	connLock   sync.Mutex
 
 	cam     map[tcpip.LinkAddress]int
@@ -45,17 +45,14 @@ type Switch struct {
 	writeLock sync.Mutex
 
 	gateway VirtualDevice
-
-	protocol protocol
 }
 
-func NewSwitch(debug bool, mtu int, protocol types.Protocol) *Switch {
+func NewSwitch(debug bool, mtu int) *Switch {
 	return &Switch{
 		debug:               debug,
 		maxTransmissionUnit: mtu,
-		conns:               make(map[int]net.Conn),
+		conns:               make(map[int]protocolConn),
 		cam:                 make(map[tcpip.LinkAddress]int),
-		protocol:            protocolImplementation(protocol),
 	}
 }
 
@@ -73,13 +70,14 @@ func (e *Switch) Connect(ep VirtualDevice) {
 	e.gateway = ep
 }
 
-func (e *Switch) DeliverNetworkPacket(protocol tcpip.NetworkProtocolNumber, pkt stack.PacketBufferPtr) {
+func (e *Switch) DeliverNetworkPacket(_ tcpip.NetworkProtocolNumber, pkt stack.PacketBufferPtr) {
 	if err := e.tx(pkt); err != nil {
 		log.Error(err)
 	}
 }
 
-func (e *Switch) Accept(ctx context.Context, conn net.Conn) error {
+func (e *Switch) Accept(ctx context.Context, rawConn net.Conn, protocol types.Protocol) error {
+	conn := protocolConn{Conn: rawConn, protocolImpl: protocolImplementation(protocol)}
 	log.Infof("new connection from %s to %s", conn.RemoteAddr().String(), conn.LocalAddr().String())
 	id, failed := e.connect(conn)
 	if failed {
@@ -100,7 +98,7 @@ func (e *Switch) Accept(ctx context.Context, conn net.Conn) error {
 	return nil
 }
 
-func (e *Switch) connect(conn net.Conn) (int, bool) {
+func (e *Switch) connect(conn protocolConn) (int, bool) {
 	e.connLock.Lock()
 	defer e.connLock.Unlock()
 
@@ -112,23 +110,10 @@ func (e *Switch) connect(conn net.Conn) (int, bool) {
 }
 
 func (e *Switch) tx(pkt stack.PacketBufferPtr) error {
-	if e.protocol.Stream() {
-		return e.txStream(pkt, e.protocol.(streamProtocol))
-	}
-	return e.txNonStream(pkt)
+	return e.txPkt(pkt)
 }
 
-func (e *Switch) txNonStream(pkt stack.PacketBufferPtr) error {
-	return e.txBuf(pkt, nil)
-}
-
-func (e *Switch) txStream(pkt stack.PacketBufferPtr, sProtocol streamProtocol) error {
-	size := sProtocol.Buf()
-	sProtocol.Write(size, pkt.Size())
-	return e.txBuf(pkt, size)
-}
-
-func (e *Switch) txBuf(pkt stack.PacketBufferPtr, size []byte) error {
+func (e *Switch) txPkt(pkt stack.PacketBufferPtr) error {
 	e.writeLock.Lock()
 	defer e.writeLock.Unlock()
 
@@ -151,14 +136,9 @@ func (e *Switch) txBuf(pkt stack.PacketBufferPtr, size []byte) error {
 			if id == srcID {
 				continue
 			}
-			if len(size) > 0 {
-				if _, err := conn.Write(size); err != nil {
-					e.disconnect(id, conn)
-					return err
-				}
-			}
-			if _, err := conn.Write(buf); err != nil {
-				e.disconnect(id, conn)
+
+			err := e.txBuf(id, conn, buf)
+			if err != nil {
 				return err
 			}
 
@@ -173,17 +153,28 @@ func (e *Switch) txBuf(pkt stack.PacketBufferPtr, size []byte) error {
 		}
 		e.camLock.RUnlock()
 		conn := e.conns[id]
-		if len(size) > 0 {
-			if _, err := conn.Write(size); err != nil {
-				e.disconnect(id, conn)
-				return err
-			}
-		}
-		if _, err := conn.Write(buf); err != nil {
-			e.disconnect(id, conn)
+		err := e.txBuf(id, conn, buf)
+		if err != nil {
 			return err
 		}
 		atomic.AddUint64(&e.Sent, uint64(pkt.Size()))
+	}
+	return nil
+}
+
+func (e *Switch) txBuf(id int, conn protocolConn, buf []byte) error {
+	if conn.protocolImpl.Stream() {
+		size := conn.protocolImpl.(streamProtocol).Buf()
+		conn.protocolImpl.(streamProtocol).Write(size, len(buf))
+
+		if _, err := conn.Write(size); err != nil {
+			e.disconnect(id, conn)
+			return err
+		}
+	}
+	if _, err := conn.Write(buf); err != nil {
+		e.disconnect(id, conn)
+		return err
 	}
 	return nil
 }
@@ -201,9 +192,9 @@ func (e *Switch) disconnect(id int, conn net.Conn) {
 	delete(e.conns, id)
 }
 
-func (e *Switch) rx(ctx context.Context, id int, conn net.Conn) error {
-	if e.protocol.Stream() {
-		return e.rxStream(ctx, id, conn, e.protocol.(streamProtocol))
+func (e *Switch) rx(ctx context.Context, id int, conn protocolConn) error {
+	if conn.protocolImpl.Stream() {
+		return e.rxStream(ctx, id, conn, conn.protocolImpl.(streamProtocol))
 	}
 	return e.rxNonStream(ctx, id, conn)
 }
@@ -254,7 +245,7 @@ loop:
 	return nil
 }
 
-func (e *Switch) rxBuf(ctx context.Context, id int, buf []byte) {
+func (e *Switch) rxBuf(_ context.Context, id int, buf []byte) {
 	if e.debug {
 		packet := gopacket.NewPacket(buf, layers.LayerTypeEthernet, gopacket.Default)
 		log.Info(packet.String())

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -48,19 +48,19 @@ type Configuration struct {
 	// Allow to assign a pre-defined MAC address to an Hyperkit VM
 	VpnKitUUIDMacAddresses map[string]string
 
-	// Qemu or Hyperkit protocol
-	// Qemu protocol is 32bits big endian size of the packet, then the packet.
-	// Hyperkit protocol is handshake, then 16bits little endian size of packet, then the packet.
-	// Bess protocol transfers bare L2 packets as SOCK_SEQPACKET.
+	// Protocol to be used. Only for /connect mux
 	Protocol Protocol
 }
 
 type Protocol string
 
 const (
+	// HyperKitProtocol is handshake, then 16bits little endian size of packet, then the packet.
 	HyperKitProtocol Protocol = "hyperkit"
-	QemuProtocol     Protocol = "qemu"
-	BessProtocol     Protocol = "bess"
+	// QemuProtocol is 32bits big endian size of the packet, then the packet.
+	QemuProtocol Protocol = "qemu"
+	// BessProtocol transfers bare L2 packets as SOCK_SEQPACKET.
+	BessProtocol Protocol = "bess"
 )
 
 type Zone struct {

--- a/pkg/virtualnetwork/bess.go
+++ b/pkg/virtualnetwork/bess.go
@@ -3,8 +3,10 @@ package virtualnetwork
 import (
 	"context"
 	"net"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
 )
 
 func (n *VirtualNetwork) AcceptBess(ctx context.Context, conn net.Conn) error {
-	return n.networkSwitch.Accept(ctx, conn)
+	return n.networkSwitch.Accept(ctx, conn, types.BessProtocol)
 }

--- a/pkg/virtualnetwork/mux.go
+++ b/pkg/virtualnetwork/mux.go
@@ -45,7 +45,7 @@ func (n *VirtualNetwork) Mux() *http.ServeMux {
 			return
 		}
 
-		_ = n.networkSwitch.Accept(context.Background(), conn)
+		_ = n.networkSwitch.Accept(context.Background(), conn, n.configuration.Protocol)
 	})
 	mux.HandleFunc("/tunnel", func(w http.ResponseWriter, r *http.Request) {
 		ip := r.URL.Query().Get("ip")

--- a/pkg/virtualnetwork/qemu.go
+++ b/pkg/virtualnetwork/qemu.go
@@ -3,8 +3,10 @@ package virtualnetwork
 import (
 	"context"
 	"net"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
 )
 
 func (n *VirtualNetwork) AcceptQemu(ctx context.Context, conn net.Conn) error {
-	return n.networkSwitch.Accept(ctx, conn)
+	return n.networkSwitch.Accept(ctx, conn, types.QemuProtocol)
 }

--- a/pkg/virtualnetwork/virtualnetwork.go
+++ b/pkg/virtualnetwork/virtualnetwork.go
@@ -45,7 +45,7 @@ func New(configuration *types.Configuration) (*VirtualNetwork, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create tap endpoint")
 	}
-	networkSwitch := tap.NewSwitch(configuration.Debug, configuration.MTU, configuration.Protocol)
+	networkSwitch := tap.NewSwitch(configuration.Debug, configuration.MTU)
 	tapEndpoint.Connect(networkSwitch)
 	networkSwitch.Connect(tapEndpoint)
 

--- a/pkg/virtualnetwork/vpnkit.go
+++ b/pkg/virtualnetwork/vpnkit.go
@@ -16,7 +16,7 @@ func (n *VirtualNetwork) AcceptVpnKit(conn net.Conn) error {
 	if err := vpnkitHandshake(conn, n.configuration); err != nil {
 		log.Error(err)
 	}
-	_ = n.networkSwitch.Accept(context.Background(), conn)
+	_ = n.networkSwitch.Accept(context.Background(), conn, types.HyperKitProtocol)
 	return nil
 }
 


### PR DESCRIPTION
This support enables usage of multiple different protocols at the same time. 

fixes #86 

**Compatibility**
The code should be backward compatible. Just that now Accept methods like  AcceptQemu, AcceptBess takes care of setting the protocol themself. 

Even if the protocol mentioned in configuration is wrong, these Accept methods takes priority and sets proper one. 
Note: The configuration still has Protocol and this is used for /connect mux.

**Usecase**
This will enable us to create a user-space network with multiple different hypervisors (eg: QEMU & VZ in macOS)