### PR TITLE
connect over stdio

### DIFF
--- a/cmd/vm/main_linux.go
+++ b/cmd/vm/main_linux.go
@@ -79,12 +79,14 @@ func run() error {
 	}
 	defer conn.Close()
 
-	req, err := http.NewRequest("POST", path, nil)
-	if err != nil {
-		return err
-	}
-	if err := req.Write(conn); err != nil {
-		return err
+	if path != "" {
+		req, err := http.NewRequest("POST", path, nil)
+		if err != nil {
+			return err
+		}
+		if err := req.Write(conn); err != nil {
+			return err
+		}
 	}
 
 	tap, err := water.New(water.Config{

--- a/pkg/net/stdio/dial.go
+++ b/pkg/net/stdio/dial.go
@@ -1,0 +1,51 @@
+package stdio
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func Dial(endpoint string, arg ...string) (net.Conn, error) {
+	cmd := exec.Command(endpoint, arg...)
+	cmd.Stderr = os.Stderr
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	local := IoAddr{path: strconv.Itoa(os.Getpid())}
+	remote := IoAddr{path: strconv.Itoa(cmd.Process.Pid)}
+	conn := IoConn{
+		reader: stdout,
+		writer: stdin,
+		local:  local,
+		remote: remote,
+		close:  cmd.Process.Kill,
+	}
+	return conn, nil
+}
+
+func GetStdioConn() net.Conn {
+	local := IoAddr{path: strconv.Itoa(os.Getpid())}
+	remote := IoAddr{path: "remote"}
+	conn := IoConn{
+		writer: os.Stdout,
+		reader: os.Stdin,
+		local:  local,
+		remote: remote,
+	}
+	return conn
+}

--- a/pkg/net/stdio/ioaddr.go
+++ b/pkg/net/stdio/ioaddr.go
@@ -1,0 +1,12 @@
+package stdio
+
+type IoAddr struct {
+	path string
+}
+
+func (a IoAddr) Network() string {
+	return "stdio"
+}
+func (a IoAddr) String() string {
+	return a.path
+}

--- a/pkg/net/stdio/ioconn.go
+++ b/pkg/net/stdio/ioconn.go
@@ -1,0 +1,50 @@
+package stdio
+
+import (
+	"io"
+	"net"
+	"time"
+)
+
+type IoConn struct {
+	writer io.Writer
+	reader io.Reader
+	local  net.Addr
+	remote net.Addr
+	close  func() error
+}
+
+func (c IoConn) Read(b []byte) (n int, err error) {
+	return c.reader.Read(b)
+}
+
+func (c IoConn) Write(b []byte) (n int, err error) {
+	return c.writer.Write(b)
+}
+
+func (c IoConn) Close() error {
+	if c.close != nil {
+		return c.close()
+	}
+	return nil
+}
+
+func (c IoConn) LocalAddr() net.Addr {
+	return c.local
+}
+
+func (c IoConn) RemoteAddr() net.Addr {
+	return c.remote
+}
+
+func (c IoConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (c IoConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (c IoConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}

--- a/pkg/transport/dial_linux.go
+++ b/pkg/transport/dial_linux.go
@@ -1,10 +1,12 @@
 package transport
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"strconv"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/net/stdio"
 	mdlayhervsock "github.com/mdlayher/vsock"
 	"github.com/pkg/errors"
 )
@@ -29,6 +31,15 @@ func Dial(endpoint string) (net.Conn, string, error) {
 	case "unix":
 		conn, err := net.Dial("unix", parsed.Path)
 		return conn, "/connect", err
+	case "stdio":
+		var values []string
+		for k, vs := range parsed.Query() {
+			for _, v := range vs {
+				values = append(values, fmt.Sprintf("-%s=%s", k, v))
+			}
+		}
+		conn, err := stdio.Dial(parsed.Path, values...)
+		return conn, "", err
 	default:
 		return nil, "", errors.New("unexpected scheme")
 	}

--- a/test/wsl.sh
+++ b/test/wsl.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -x
+
+./bin/vm \
+    -url="stdio:$(pwd)/bin/gvproxy-windows.exe?listen-stdio=accept&debug=true" \
+    -iface="eth1" \
+    -stop-if-exist="" \
+    -debug


### PR DESCRIPTION
This adds stdio as a way to communicate between `gvproxy` and `vm` mainly for use with WSL2, although it should work for other cases as well.

When network connections between WSL2 and the Windows host are blocked, stdio is the only reliable way to establish a channel between WSL2 and the Windows host. Hyper-V socket for WSL2 is a possibility, but it requires undocumented APIs and admin privileges.

Related to #139. Related: https://github.com/microsoft/WSL/issues/4131

