### PR TITLE
Improve rxStream performance using bufio reader

### DIFF
--- a/pkg/tap/protocol.go
+++ b/pkg/tap/protocol.go
@@ -1,6 +1,8 @@
 package tap
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+)
 
 type protocol interface {
 	Stream() bool

--- a/pkg/tap/switch.go
+++ b/pkg/tap/switch.go
@@ -1,6 +1,7 @@
 package tap
 
 import (
+	"bufio"
 	"context"
 	"io"
 	"net"
@@ -220,6 +221,7 @@ loop:
 }
 
 func (e *Switch) rxStream(ctx context.Context, id int, conn net.Conn, sProtocol streamProtocol) error {
+	reader := bufio.NewReader(conn)
 	sizeBuf := sProtocol.Buf()
 loop:
 	for {
@@ -229,14 +231,14 @@ loop:
 		default:
 			// passthrough
 		}
-		_, err := io.ReadFull(conn, sizeBuf)
+		_, err := io.ReadFull(reader, sizeBuf)
 		if err != nil {
 			return errors.Wrap(err, "cannot read size from socket")
 		}
 		size := sProtocol.Read(sizeBuf)
 
 		buf := make([]byte, size)
-		_, err = io.ReadFull(conn, buf)
+		_, err = io.ReadFull(reader, buf)
 		if err != nil {
 			return errors.Wrap(err, "cannot read packet from socket")
 		}


### PR DESCRIPTION
New report with bufio reader
```
[test@localhost ~]$ LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing
Connecting to host host.crc.testing, port 5201
[  4] local 192.168.127.2 port 41688 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bandwidth       Retr  Cwnd
[  4]   0.00-1.00   sec   193 MBytes  1.62 Gbits/sec    0    529 KBytes
[  4]   1.00-2.00   sec   205 MBytes  1.72 Gbits/sec    0    529 KBytes
[  4]   2.00-3.00   sec   206 MBytes  1.73 Gbits/sec    0    529 KBytes
[  4]   3.00-4.00   sec   208 MBytes  1.74 Gbits/sec    0    529 KBytes
[  4]   4.00-5.00   sec   208 MBytes  1.75 Gbits/sec    0    529 KBytes
[  4]   5.00-6.00   sec   203 MBytes  1.70 Gbits/sec    0    529 KBytes
[  4]   6.00-7.00   sec   196 MBytes  1.65 Gbits/sec    0    529 KBytes
[  4]   7.00-8.00   sec   152 MBytes  1.28 Gbits/sec    0    529 KBytes
[  4]   8.00-9.00   sec   198 MBytes  1.66 Gbits/sec    0    529 KBytes
[  4]   9.00-10.00  sec   192 MBytes  1.61 Gbits/sec    1    399 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-10.00  sec  1.92 GBytes  1.65 Gbits/sec    1             sender
[  4]   0.00-10.00  sec  1.91 GBytes  1.64 Gbits/sec                  receiver

iperf Done.
[test@localhost ~]$ LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -R
Connecting to host host.crc.testing, port 5201
Reverse mode, remote host host.crc.testing is sending
[  4] local 192.168.127.2 port 43040 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bandwidth
[  4]   0.00-1.00   sec   142 MBytes  1.19 Gbits/sec
[  4]   1.00-2.00   sec   142 MBytes  1.19 Gbits/sec
[  4]   2.00-3.00   sec   139 MBytes  1.17 Gbits/sec
[  4]   3.00-4.00   sec   139 MBytes  1.16 Gbits/sec
[  4]   4.00-5.00   sec   138 MBytes  1.16 Gbits/sec
[  4]   5.00-6.00   sec   132 MBytes  1.11 Gbits/sec
[  4]   6.00-7.00   sec   136 MBytes  1.14 Gbits/sec
[  4]   7.00-8.00   sec   137 MBytes  1.15 Gbits/sec
[  4]   8.00-9.00   sec   136 MBytes  1.14 Gbits/sec
[  4]   9.00-10.00  sec   136 MBytes  1.14 Gbits/sec
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-10.00  sec  1.35 GBytes  1.16 Gbits/sec    0             sender
[  4]   0.00-10.00  sec  1.34 GBytes  1.15 Gbits/sec                  receiver

iperf Done.
[test@localhost ~]$ LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -u
Connecting to host host.crc.testing, port 5201
[  4] local 192.168.127.2 port 42362 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bandwidth       Total Datagrams
[  4]   0.00-1.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   1.00-2.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   2.00-3.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   3.00-4.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   4.00-5.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   5.00-6.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   6.00-7.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   7.00-8.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   8.00-9.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   9.00-10.00  sec   128 KBytes  1.05 Mbits/sec  16
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Jitter    Lost/Total Datagrams
[  4]   0.00-10.00  sec  1.25 MBytes  1.05 Mbits/sec  0.167 ms  0/159 (0%)
[  4] Sent 159 datagrams

iperf Done.
[test@localhost ~]$ LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -R -u
Connecting to host host.crc.testing, port 5201
Reverse mode, remote host host.crc.testing is sending
[  4] local 192.168.127.2 port 40664 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bandwidth       Jitter    Lost/Total Datagrams
[  4]   0.00-1.00   sec   136 KBytes  1.11 Mbits/sec  37299069969.359 ms  0/17 (0%)
[  4]   1.00-2.00   sec   128 KBytes  1.05 Mbits/sec  13281233906.164 ms  0/16 (0%)
[  4]   2.00-3.00   sec   128 KBytes  1.05 Mbits/sec  4729103814.604 ms  0/16 (0%)
[  4]   3.00-4.00   sec   128 KBytes  1.05 Mbits/sec  1683911528.736 ms  0/16 (0%)
[  4]   4.00-5.00   sec   128 KBytes  1.05 Mbits/sec  599597333.517 ms  0/16 (0%)
[  4]   5.00-6.00   sec   128 KBytes  1.05 Mbits/sec  213501099.256 ms  0/16 (0%)
[  4]   6.00-7.00   sec   128 KBytes  1.05 Mbits/sec  76022218.521 ms  0/16 (0%)
[  4]   7.00-8.00   sec   128 KBytes  1.05 Mbits/sec  27069545.487 ms  0/16 (0%)
[  4]   8.00-9.00   sec   128 KBytes  1.05 Mbits/sec  9638765.001 ms  0/16 (0%)
[  4]   9.00-10.00  sec   128 KBytes  1.05 Mbits/sec  3432114.984 ms  0/16 (0%)
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Jitter    Lost/Total Datagrams
[  4]   0.00-10.00  sec  1.26 MBytes  1.05 Mbits/sec  3432114.984 ms  0/161 (0%)
[  4] Sent 161 datagrams

iperf Done.
```

Old report
```
[test@localhost ~]$ LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing
Connecting to host host.crc.testing, port 5201
[  4] local 192.168.127.2 port 34950 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bandwidth       Retr  Cwnd
[  4]   0.00-1.00   sec   145 MBytes  1.22 Gbits/sec    0    428 KBytes
[  4]   1.00-2.00   sec   152 MBytes  1.28 Gbits/sec    0    495 KBytes
[  4]   2.00-3.00   sec   147 MBytes  1.23 Gbits/sec    0    519 KBytes
[  4]   3.00-4.00   sec   143 MBytes  1.20 Gbits/sec    0    519 KBytes
[  4]   4.00-5.00   sec   139 MBytes  1.17 Gbits/sec    0    519 KBytes
[  4]   5.00-6.00   sec   149 MBytes  1.25 Gbits/sec    0    519 KBytes
[  4]   6.00-7.00   sec   151 MBytes  1.26 Gbits/sec    0    519 KBytes
[  4]   7.00-8.00   sec   142 MBytes  1.19 Gbits/sec    0    519 KBytes
[  4]   8.00-9.00   sec   135 MBytes  1.13 Gbits/sec    0    519 KBytes
[  4]   9.00-10.00  sec   126 MBytes  1.06 Gbits/sec    0    519 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-10.00  sec  1.40 GBytes  1.20 Gbits/sec    0             sender
[  4]   0.00-10.00  sec  1.39 GBytes  1.20 Gbits/sec                  receiver

iperf Done.
[test@localhost ~]$ LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -R
Connecting to host host.crc.testing, port 5201
Reverse mode, remote host host.crc.testing is sending
[  4] local 192.168.127.2 port 51686 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bandwidth
[  4]   0.00-1.00   sec   140 MBytes  1.17 Gbits/sec
[  4]   1.00-2.00   sec   142 MBytes  1.19 Gbits/sec
[  4]   2.00-3.00   sec   139 MBytes  1.17 Gbits/sec
[  4]   3.00-4.00   sec   137 MBytes  1.15 Gbits/sec
[  4]   4.00-5.00   sec   140 MBytes  1.17 Gbits/sec
[  4]   5.00-6.00   sec   118 MBytes   988 Mbits/sec
[  4]   6.00-7.00   sec   135 MBytes  1.13 Gbits/sec
[  4]   7.00-8.00   sec   135 MBytes  1.13 Gbits/sec
[  4]   8.00-9.00   sec   133 MBytes  1.12 Gbits/sec
[  4]   9.00-10.00  sec   130 MBytes  1.09 Gbits/sec
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-10.00  sec  1.32 GBytes  1.13 Gbits/sec    0             sender
[  4]   0.00-10.00  sec  1.32 GBytes  1.13 Gbits/sec                  receiver

iperf Done.
[test@localhost ~]$ LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -u
Connecting to host host.crc.testing, port 5201
[  4] local 192.168.127.2 port 53445 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bandwidth       Total Datagrams
[  4]   0.00-1.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   1.00-2.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   2.00-3.01   sec   128 KBytes  1.04 Mbits/sec  16
[  4]   3.01-4.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   4.00-5.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   5.00-6.01   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   6.01-7.01   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   7.01-8.01   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   8.01-9.00   sec   128 KBytes  1.05 Mbits/sec  16
[  4]   9.00-10.00  sec   128 KBytes  1.05 Mbits/sec  16
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Jitter    Lost/Total Datagrams
[  4]   0.00-10.00  sec  1.25 MBytes  1.05 Mbits/sec  0.151 ms  0/159 (0%)
[  4] Sent 159 datagrams

iperf Done.
[test@localhost ~]$ LD_LIBRARY_PATH=. ./iperf3 -c host.crc.testing -R -u
Connecting to host host.crc.testing, port 5201
Reverse mode, remote host host.crc.testing is sending
[  4] local 192.168.127.2 port 42615 connected to 192.168.127.254 port 5201
[ ID] Interval           Transfer     Bandwidth       Jitter    Lost/Total Datagrams
[  4]   0.00-1.00   sec   136 KBytes  1.11 Mbits/sec  37299069969.779 ms  0/17 (0%)
[  4]   1.00-2.00   sec   128 KBytes  1.05 Mbits/sec  13281233906.246 ms  0/16 (0%)
[  4]   2.00-3.00   sec   128 KBytes  1.05 Mbits/sec  4729103814.593 ms  0/16 (0%)
[  4]   3.00-4.00   sec   128 KBytes  1.05 Mbits/sec  1683911528.705 ms  0/16 (0%)
[  4]   4.00-5.00   sec   128 KBytes  1.05 Mbits/sec  599597333.429 ms  0/16 (0%)
[  4]   5.00-6.00   sec   128 KBytes  1.05 Mbits/sec  213501099.189 ms  0/16 (0%)
[  4]   6.00-7.00   sec   128 KBytes  1.05 Mbits/sec  76022218.312 ms  0/16 (0%)
[  4]   7.00-8.00   sec   128 KBytes  1.05 Mbits/sec  27069545.394 ms  0/16 (0%)
[  4]   8.00-9.00   sec   128 KBytes  1.05 Mbits/sec  9638764.920 ms  0/16 (0%)
[  4]   9.00-10.00  sec   128 KBytes  1.05 Mbits/sec  3432114.971 ms  0/16 (0%)
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Jitter    Lost/Total Datagrams
[  4]   0.00-10.00  sec  1.26 MBytes  1.06 Mbits/sec  3432114.971 ms  0/161 (0%)
[  4] Sent 161 datagrams

iperf Done.
```