### PR TITLE
ghactions: Upload all binaries

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,8 +24,8 @@ jobs:
 
     - uses: actions/upload-artifact@v3
       with:
-        name: gvproxy
-        path: bin/gvproxy*
+        name: gvisor-tap-vsock-binaries
+        path: bin/*
 
   tests:
     runs-on: macos-11 # Only Mac runners support nested virt


### PR DESCRIPTION
At the moment, all bin/gvisor* are uploaded by the
actions/upload-artifacts, but the other binaries (qemu-wrapper, vm,
win-sshproxy.exe) can be useful to have.
This commit uploads all of bin/ as a gvisor-tap-vsock-binaries artifact.