### PR TITLE
set proper protocol for stdio

### DIFF
--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -366,7 +366,7 @@ func run(ctx context.Context, g *errgroup.Group, configuration *types.Configurat
 	if stdioSocket != "" {
 		g.Go(func() error {
 			conn := stdio.GetStdioConn()
-			return vn.AcceptQemu(ctx, conn)
+			return vn.AcceptStdio(ctx, conn)
 		})
 	}
 

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -61,6 +61,8 @@ const (
 	QemuProtocol Protocol = "qemu"
 	// BessProtocol transfers bare L2 packets as SOCK_SEQPACKET.
 	BessProtocol Protocol = "bess"
+	// StdioProtocol is HyperKitProtocol without the handshake
+	StdioProtocol Protocol = "stdio"
 )
 
 type Zone struct {

--- a/pkg/virtualnetwork/stdio.go
+++ b/pkg/virtualnetwork/stdio.go
@@ -1,0 +1,12 @@
+package virtualnetwork
+
+import (
+	"context"
+	"net"
+
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
+)
+
+func (n *VirtualNetwork) AcceptStdio(ctx context.Context, conn net.Conn) error {
+	return n.networkSwitch.Accept(ctx, conn, types.StdioProtocol)
+}


### PR DESCRIPTION
In #177, the stdio connection was relying on the behavior of the virtualnetwork using the protocol specified on the config created in the gvproxy command. #175 changed this to ignore the protocol on the config and use the protocol defined in each of the Accept* methods. 

This adds an entry for the stdio connection as a separate type and uses that.