### PR TITLE
[CI:BUILD] Packit: Initial Enablement

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# This script handles any custom processing of the spec file generated using the `post-upstream-clone`
+# action and gets used by the fix-spec-file action in .packit.yaml.
+
+set -eo pipefail
+
+REPO="gvisor-tap-vsock"
+SPEC=$REPO.spec
+
+# Get Version from HEAD
+# FIXME: Don't know where to fetch this from yet
+VERSION=0.0
+
+# Generate source tarball from HEAD
+git archive --prefix=$REPO-$VERSION/ -o $REPO-$VERSION.tar.gz HEAD
+
+# RPM Spec modifications
+
+# Use the Version from version/version.go in rpm spec
+sed -i "s/^Version:.*/Version: $VERSION/" $SPEC
+
+# Use Packit's supplied variable in the Release field in rpm spec.
+# podman.spec is generated using `rpkg spec --outdir ./` as mentioned in the
+# `post-upstream-clone` action in .packit.yaml.
+sed -i "s/^Release:.*/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" $SPEC
+
+# Use above generated tarball as Source in rpm spec
+sed -i "s/^Source:.*.tar.gz/Source: $REPO-$VERSION.tar.gz/" $SPEC
+
+# Use the right build dir for autosetup stage in rpm spec
+sed -i "s/^%setup.*/%autosetup -Sgit -n %{name}-$VERSION/" $SPEC

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,30 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+# Build targets can be found at:
+# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
+
+specfile_path: gvisor-tap-vsock.spec
+
+jobs:
+  - &copr
+    job: copr_build
+    trigger: pull_request
+    owner: rhcontainerbot
+    project: packit-builds
+    enable_net: true
+    srpm_build_deps:
+      - make
+      - rpkg
+    actions:
+      post-upstream-clone:
+        - "rpkg spec --outdir ./"
+      fix-spec-file:
+        - "bash .packit.sh"
+
+  - <<: *copr
+    # Run on commit to main branch
+    trigger: commit
+    branch: main
+    project: podman-next

--- a/gvisor-tap-vsock.spec.rpkg
+++ b/gvisor-tap-vsock.spec.rpkg
@@ -1,0 +1,85 @@
+# For automatic rebuilds in COPR
+
+# The following tag is to get correct syntax highlighting for this file in vim text editor
+# vim: syntax=spec
+
+%global with_debug 1
+
+%if 0%{?with_debug}
+%global _find_debuginfo_dwz_opts %{nil}
+%global _dwz_low_mem_die_limit 0
+%else
+%global debug_package %{nil}
+%endif
+
+# RHEL 8's default %%gobuild macro doesn't account for the BUILDTAGS variable, so we
+# set it separately here and do not depend on RHEL 8's go-srpm-macros package.
+%if !0%{?fedora} && 0%{?rhel} <= 8
+%define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback libtrust_openssl ${BUILDTAGS:-}" -ldflags "-linkmode=external -compressdwarf=false ${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'" -a -v -x %{?**};
+%endif
+
+Name: {{{ git_dir_name }}}
+Epoch: 101
+Version: {{{ git_dir_version }}}
+Release: 1%{?dist}
+Summary: Go replacement for libslirp and VPNKit
+License: Apache-2.0
+URL: https://github.com/containers/gvisor-tap-vsock
+VCS: {{{ git_dir_vcs }}}
+Source: {{{ git_dir_pack }}}
+BuildRequires: gcc
+BuildRequires: golang >= 1.16.6
+BuildRequires: git-core
+%if 0%{?fedora} || 0%{?rhel} >= 9
+BuildRequires: go-rpm-macros
+%endif
+Provides: podman-gvproxy = %{epoch}:%{version}-%{release}
+
+%description
+%{summary}
+
+%{name} is based on the network stack of gVisor. Compared to libslirp,
+gvisor-tap-vsock brings a configurable DNS server and
+dynamic port forwarding.
+
+%prep
+{{{ git_dir_setup_macro }}}
+
+%build
+%set_build_flags
+%global gomodulesmode GO111MODULE=on
+export CGO_CFLAGS=$CFLAGS
+# These extra flags present in $CFLAGS have been skipped for now as they break the build
+CGO_CFLAGS=$(echo $CGO_CFLAGS | sed 's/-flto=auto//g')
+CGO_CFLAGS=$(echo $CGO_CFLAGS | sed 's/-Wp,D_GLIBCXX_ASSERTIONS//g')
+CGO_CFLAGS=$(echo $CGO_CFLAGS | sed 's/-specs=\/usr\/lib\/rpm\/redhat\/redhat-annobin-cc1//g')
+
+%ifarch x86_64
+export CGO_CFLAGS+=" -m64 -mtune=generic -fcf-protection=full"
+%endif
+
+export LDFLAGS=''
+
+mkdir _build
+cd _build
+mkdir -p src/%{provider}.%{provider_tld}/%{project}
+ln -s ../../../../ src/%{import_path}
+cd ..
+ln -s vendor src
+
+export GOPATH=$(pwd)/_build:$(pwd)
+%gobuild -o bin/gvproxy ./cmd/gvproxy
+%gobuild -o bin/vm ./cmd/vm
+
+%install
+install -dp %{buildroot}%{_libexecdir}/podman
+install -p -m0755 bin/gvproxy %{buildroot}%{_libexecdir}/podman
+install -p -m0755 bin/vm %{buildroot}%{_libexecdir}/podman
+
+%files
+%dir %{_libexecdir}/podman
+%{_libexecdir}/podman/gvproxy
+%{_libexecdir}/podman/vm
+
+%changelog
+{{{ git_dir_changelog }}}


### PR DESCRIPTION
This commit adds Packit configuration files which will trigger rpm builds on copr:`rhcontainerbot/packit-builds` on every PR as well as on copr:`rhcontainerbot/podman-next` on every commit to main branch.

This commit will ensure main branch is always buildable on all supported Fedora and CentOS Stream versions for aarch64 and x86_64.

TODO: enable build checks for s390x and ppc64le while ensuring they don't take too long to build.

The packit builds reuse the `$NAME.spec.rpkg` present upstream and are thus independent of Fedora / CentOS dist-git.


