### PR TITLE
Packit: disable builds on podman-next copr

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -24,8 +24,8 @@ jobs:
       fix-spec-file:
         - "bash .packit.sh"
 
-  - <<: *copr
+    #- <<: *copr
     # Run on commit to main branch
-    trigger: commit
-    branch: main
-    project: podman-next
+    #trigger: commit
+    #branch: main
+    #project: podman-next


### PR DESCRIPTION
Podman upstream now syncs the rpm spec file with Fedora dist-git. This podman.spec also builds gvisor-tap-vsock as a subpackage which conflicts with the standalone gvisor-tap-vsock package on podman-next. Ref: https://github.com/containers/podman/pull/18465

This commit will disable build tasks on `rhcontainerbot/podman-next` to avoid installation conflicts.

The copr build tasks on every PR will still continue to check for any potential build issues.

@baude @cfergeau PTAL