### PR TITLE
dns: Support CNAME, MX, SRV and TXT records

### DIFF
--- a/pkg/services/dns/dns.go
+++ b/pkg/services/dns/dns.go
@@ -89,23 +89,6 @@ func (h *dnsHandler) addAnswers(m *dns.Msg) {
 			PreferGo: false,
 		}
 		switch q.Qtype {
-		case dns.TypeNS:
-			records, err := resolver.LookupNS(context.TODO(), q.Name)
-			if err != nil {
-				m.Rcode = dns.RcodeNameError
-				return
-			}
-			for _, ns := range records {
-				m.Answer = append(m.Answer, &dns.NS{
-					Hdr: dns.RR_Header{
-						Name:   q.Name,
-						Rrtype: dns.TypeNS,
-						Class:  dns.ClassINET,
-						Ttl:    0,
-					},
-					Ns: ns.Host,
-				})
-			}
 		case dns.TypeA:
 			ips, err := resolver.LookupIPAddr(context.TODO(), q.Name)
 			if err != nil {
@@ -124,6 +107,23 @@ func (h *dnsHandler) addAnswers(m *dns.Msg) {
 						Ttl:    0,
 					},
 					A: ip.IP.To4(),
+				})
+			}
+		case dns.TypeNS:
+			records, err := resolver.LookupNS(context.TODO(), q.Name)
+			if err != nil {
+				m.Rcode = dns.RcodeNameError
+				return
+			}
+			for _, ns := range records {
+				m.Answer = append(m.Answer, &dns.NS{
+					Hdr: dns.RR_Header{
+						Name:   q.Name,
+						Rrtype: dns.TypeNS,
+						Class:  dns.ClassINET,
+						Ttl:    0,
+					},
+					Ns: ns.Host,
 				})
 			}
 		}

--- a/pkg/services/dns/dns.go
+++ b/pkg/services/dns/dns.go
@@ -109,6 +109,39 @@ func (h *dnsHandler) addAnswers(m *dns.Msg) {
 					A: ip.IP.To4(),
 				})
 			}
+		case dns.TypeCNAME:
+			cname, err := resolver.LookupCNAME(context.TODO(), q.Name)
+			if err != nil {
+				m.Rcode = dns.RcodeNameError
+				return
+			}
+			m.Answer = append(m.Answer, &dns.CNAME{
+				Hdr: dns.RR_Header{
+					Name:   q.Name,
+					Rrtype: dns.TypeCNAME,
+					Class:  dns.ClassINET,
+					Ttl:    0,
+				},
+				Target: cname,
+			})
+		case dns.TypeMX:
+			records, err := resolver.LookupMX(context.TODO(), q.Name)
+			if err != nil {
+				m.Rcode = dns.RcodeNameError
+				return
+			}
+			for _, mx := range records {
+				m.Answer = append(m.Answer, &dns.MX{
+					Hdr: dns.RR_Header{
+						Name:   q.Name,
+						Rrtype: dns.TypeMX,
+						Class:  dns.ClassINET,
+						Ttl:    0,
+					},
+					Mx:         mx.Host,
+					Preference: mx.Pref,
+				})
+			}
 		case dns.TypeNS:
 			records, err := resolver.LookupNS(context.TODO(), q.Name)
 			if err != nil {
@@ -126,6 +159,41 @@ func (h *dnsHandler) addAnswers(m *dns.Msg) {
 					Ns: ns.Host,
 				})
 			}
+		case dns.TypeSRV:
+			_, records, err := resolver.LookupSRV(context.TODO(), "", "", q.Name)
+			if err != nil {
+				m.Rcode = dns.RcodeNameError
+				return
+			}
+			for _, srv := range records {
+				m.Answer = append(m.Answer, &dns.SRV{
+					Hdr: dns.RR_Header{
+						Name:   q.Name,
+						Rrtype: dns.TypeSRV,
+						Class:  dns.ClassINET,
+						Ttl:    0,
+					},
+					Port:     srv.Port,
+					Priority: srv.Priority,
+					Target:   srv.Target,
+					Weight:   srv.Weight,
+				})
+			}
+		case dns.TypeTXT:
+			records, err := resolver.LookupTXT(context.TODO(), q.Name)
+			if err != nil {
+				m.Rcode = dns.RcodeNameError
+				return
+			}
+			m.Answer = append(m.Answer, &dns.TXT{
+				Hdr: dns.RR_Header{
+					Name:   q.Name,
+					Rrtype: dns.TypeTXT,
+					Class:  dns.ClassINET,
+					Ttl:    0,
+				},
+				Txt: records,
+			})
 		}
 	}
 }

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -53,6 +53,33 @@ var _ = Describe("dns", func() {
 		Expect(string(out)).To(ContainSubstring("Address: 52.200.142.250"))
 	})
 
+	It("should resolve CNAME record for www.wikipedia.org", func() {
+		out, err := sshExec("nslookup -query=cname www.wikipedia.org")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(string(out)).To(ContainSubstring("www.wikipedia.org	canonical name = dyna.wikimedia.org."))
+	})
+	It("should resolve MX record for wikipedia.org", func() {
+		out, err := sshExec("nslookup -query=mx wikipedia.org")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(string(out)).To(ContainSubstring("wikipedia.org	mail exchanger = 10 mx1001.wikimedia.org."))
+	})
+
+	It("should resolve NS record for wikipedia.org", func() {
+		out, err := sshExec("nslookup -query=ns wikipedia.org")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(string(out)).To(ContainSubstring("wikipedia.org	nameserver = ns0.wikimedia.org."))
+	})
+	It("should resolve LDAP SRV record for google.com", func() {
+		out, err := sshExec("nslookup -query=srv _ldap._tcp.google.com")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(string(out)).To(ContainSubstring(`_ldap._tcp.google.com	service = 5 0 389 ldap.google.com.`))
+	})
+	It("should resolve TXT for wikipedia.org", func() {
+		out, err := sshExec("nslookup -query=txt wikipedia.org")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(string(out)).To(ContainSubstring(`"v=spf1 include:wikimedia.org ~all"`))
+	})
+
 	It("should resolve gateway.containers.internal", func() {
 		out, err := sshExec("nslookup gateway.containers.internal")
 		Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
The current implementation only supports A and NS records. This should fix
https://github.com/containers/gvisor-tap-vsock/issues/233

This can be tested with:
```
podman run -it --rm alpine nslookup -type=txt rs.joedrumgoole.com
```