### PR TITLE
packit: Build PRs into default packit COPRs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,52 +9,35 @@
 specfile_path: rpm/gvisor-tap-vsock.spec
 upstream_tag_template: v{version}
 
-jobs:
-  - &copr
-    job: copr_build
-    trigger: pull_request
-    owner: rhcontainerbot
-    project: packit-builds
-    enable_net: true
-    srpm_build_deps:
-      - make
-    targets:
-      - fedora-rawhide-aarch64
-      - fedora-rawhide-x86_64
-      - fedora-eln-aarch64
-      - fedora-eln-x86_64
-      - fedora-38-aarch64
-      - fedora-38-x86_64
-      - centos-stream-9-aarch64
-      - centos-stream-9-x86_64
-      - centos-stream-8-aarch64
-      - centos-stream-8-x86_64
+srpm_build_deps:
+  - make
 
-  - <<: *copr
-    # Run on commit to main branch
-    trigger: commit
-    branch: main
-    project: podman-next
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    enable_net: true
+    # keep in sync with https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next
     targets:
       - fedora-rawhide-aarch64
-      - fedora-rawhide-ppc64le
-      - fedora-rawhide-s390x
       - fedora-rawhide-x86_64
       - fedora-eln-aarch64
-      - fedora-eln-ppc64le
-      - fedora-eln-s390x
       - fedora-eln-x86_64
       - fedora-38-aarch64
-      - fedora-38-ppc64le
-      - fedora-38-s390x
       - fedora-38-x86_64
-      - centos-stream+epel-next-9-aarch64
-      - centos-stream+epel-next-9-ppc64le
-      - centos-stream+epel-next-9-s390x
-      - centos-stream+epel-next-9-x86_64
-      - centos-stream+epel-next-8-aarch64
-      - centos-stream+epel-next-8-ppc64le
       - centos-stream+epel-next-8-x86_64
+      - centos-stream+epel-next-8-aarch64
+      - centos-stream+epel-next-9-x86_64
+      - centos-stream+epel-next-9-aarch64
+    additional_repos:
+      - "copr://rhcontainerbot/podman-next"
+
+  # Run on commit to main branch
+  - job: copr_build
+    trigger: commit
+    enable_net: true
+    branch: main
+    owner: rhcontainerbot
+    project: podman-next
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
Building all PRs of all container projects into the same COPR does not properly isolate PRs from each other.

To avoid that, change the copr_build configuration to use the packit default COPRs, which are specific to the particular PR, and disappear after a few weeks. Depending projects should only run against what landed in gvisor-tap-vsock/main i.e. the podman-next COPR.

Unmerging the two copr jobs allows us the redundant targets: list for the "main" builds into podman-next. Specifying the target list is not necessary any more since https://github.com/packit/packit-service/issues/1499 got fixed.

----

This is exactly the same as https://github.com/containers/crun/pull/1260 ; please see the discussion there, this change needs to be applied to all container projects, and then all land together. Let's keep all the relevant discussions and tracking in  the crun PR please.