### PR TITLE
Add listen to BSDs

### DIFF
--- a/pkg/transport/listen_bsd.go
+++ b/pkg/transport/listen_bsd.go
@@ -1,0 +1,58 @@
+//go:build freebsd || netbsd || openbsd || dragonfly
+// +build freebsd netbsd openbsd dragonfly
+
+package transport
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path"
+	"strconv"
+)
+
+const DefaultURL = "vsock://null:1024/vm_directory"
+
+func Listen(endpoint string) (net.Listener, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	switch parsed.Scheme {
+	case "vsock":
+		port, err := strconv.Atoi(parsed.Port())
+		if err != nil {
+			return nil, err
+		}
+		path := path.Join(parsed.Path, fmt.Sprintf("00000002.%08x", port))
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+		return net.ListenUnix("unix", &net.UnixAddr{
+			Name: path,
+			Net:  "unix",
+		})
+	case "unix":
+		return net.Listen("unix", parsed.Path)
+	case "tcp":
+		return net.Listen("tcp", parsed.Host)
+	default:
+		return nil, errors.New("unexpected scheme")
+	}
+}
+
+func ListenUnixgram(endpoint string) (*net.UnixConn, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if parsed.Scheme != "unixgram" {
+		return nil, errors.New("unexpected scheme")
+	}
+	return net.ListenUnixgram("unixgram", &net.UnixAddr{
+		Name: parsed.Path,
+		Net:  "unixgram",
+	})
+}


### PR DESCRIPTION
Copy over Darwin's code and reuse it for the most common BSDs. It is untested in all BSDs added but in DragonFly BSD but at least it'll allow the build to succeed.

Might want to merge darwin and BSD file together but for now they are separate because we might need to add something BSD-specific.

Build might fail in DragonFly BSD because it depends on https://github.com/insomniacslk/dhcp/pull/510 , which is still not upstream. So a bump will also be needed for this specific OS.

This is for the ongoing issue https://github.com/lima-vm/lima/issues/892