### PR TITLE
Refactor transport.Listen code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ image:
 
 .PHONY: cross
 cross: $(TOOLS_BINDIR)/makefat
+	GOARCH=amd64 GOOS=freebsd  go build $(LDFLAGS) -o bin/gvproxy-freebsd-amd64 ./cmd/gvproxy
 	GOARCH=amd64 GOOS=windows go build $(LDFLAGS) -o bin/gvproxy-windows.exe ./cmd/gvproxy
 	GOARCH=amd64 GOOS=darwin  go build $(LDFLAGS) -o bin/gvproxy-darwin-amd64 ./cmd/gvproxy
 	GOARCH=arm64 GOOS=darwin  go build $(LDFLAGS) -o bin/gvproxy-darwin-arm64 ./cmd/gvproxy

--- a/pkg/transport/listen.go
+++ b/pkg/transport/listen.go
@@ -1,0 +1,26 @@
+package transport
+
+import (
+	"errors"
+	"net"
+	"net/url"
+)
+
+func defaultListenURL(url *url.URL) (net.Listener, error) {
+	switch url.Scheme {
+	case "unix":
+		return net.Listen(url.Scheme, url.Path)
+	case "tcp":
+		return net.Listen("tcp", url.Host)
+	default:
+		return nil, errors.New("unexpected scheme")
+	}
+}
+
+func Listen(endpoint string) (net.Listener, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return listenURL(parsed)
+}

--- a/pkg/transport/listen_darwin.go
+++ b/pkg/transport/listen_darwin.go
@@ -12,11 +12,7 @@ import (
 
 const DefaultURL = "vsock://null:1024/vm_directory"
 
-func Listen(endpoint string) (net.Listener, error) {
-	parsed, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
+func listenURL(parsed *url.URL) (net.Listener, error) {
 	switch parsed.Scheme {
 	case "vsock":
 		port, err := strconv.Atoi(parsed.Port())
@@ -31,12 +27,8 @@ func Listen(endpoint string) (net.Listener, error) {
 			Name: path,
 			Net:  "unix",
 		})
-	case "unix":
-		return net.Listen("unix", parsed.Path)
-	case "tcp":
-		return net.Listen("tcp", parsed.Host)
 	default:
-		return nil, errors.New("unexpected scheme")
+		return defaultListenURL(parsed)
 	}
 }
 

--- a/pkg/transport/listen_generic.go
+++ b/pkg/transport/listen_generic.go
@@ -1,0 +1,13 @@
+//go:build !darwin && !linux && !windows
+// +build !darwin,!linux,!windows
+
+package transport
+
+import (
+	"net"
+	"net/url"
+)
+
+func listenURL(url *url.URL) (net.Listener, error) {
+	return defaultListenURL(url)
+}

--- a/pkg/transport/listen_linux.go
+++ b/pkg/transport/listen_linux.go
@@ -31,17 +31,3 @@ func Listen(endpoint string) (net.Listener, error) {
 		return nil, errors.New("unexpected scheme")
 	}
 }
-
-func ListenUnixgram(endpoint string) (*net.UnixConn, error) {
-	parsed, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if parsed.Scheme != "unixgram" {
-		return nil, errors.New("unexpected scheme")
-	}
-	return net.ListenUnixgram("unixgram", &net.UnixAddr{
-		Name: parsed.Path,
-		Net:  "unixgram",
-	})
-}

--- a/pkg/transport/listen_linux.go
+++ b/pkg/transport/listen_linux.go
@@ -1,7 +1,6 @@
 package transport
 
 import (
-	"errors"
 	"net"
 	"net/url"
 	"strconv"
@@ -11,11 +10,7 @@ import (
 
 const DefaultURL = "vsock://:1024"
 
-func Listen(endpoint string) (net.Listener, error) {
-	parsed, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
+func listenURL(parsed *url.URL) (net.Listener, error) {
 	switch parsed.Scheme {
 	case "vsock":
 		port, err := strconv.Atoi(parsed.Port())
@@ -23,11 +18,9 @@ func Listen(endpoint string) (net.Listener, error) {
 			return nil, err
 		}
 		return mdlayhervsock.Listen(uint32(port), nil)
-	case "unix", "unixpacket":
+	case "unixpacket":
 		return net.Listen(parsed.Scheme, parsed.Path)
-	case "tcp":
-		return net.Listen("tcp", parsed.Host)
 	default:
-		return nil, errors.New("unexpected scheme")
+		return defaultListenURL(parsed)
 	}
 }

--- a/pkg/transport/listen_windows.go
+++ b/pkg/transport/listen_windows.go
@@ -33,11 +33,3 @@ func Listen(endpoint string) (net.Listener, error) {
 		return nil, errors.New("unexpected scheme")
 	}
 }
-
-func ListenUnixgram(endpoint string) (net.Conn, error) {
-	return nil, errors.New("unsupported 'unixgram' scheme")
-}
-
-func AcceptVfkit(listeningConn net.Conn) (net.Conn, error) {
-	return nil, errors.New("vfkit is unsupported on Windows")
-}

--- a/pkg/transport/listen_windows.go
+++ b/pkg/transport/listen_windows.go
@@ -1,7 +1,6 @@
 package transport
 
 import (
-	"errors"
 	"net"
 	"net/url"
 
@@ -10,11 +9,7 @@ import (
 
 const DefaultURL = "vsock://00000400-FACB-11E6-BD58-64006A7986D3"
 
-func Listen(endpoint string) (net.Listener, error) {
-	parsed, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
+func listenURL(parsed *url.URL) (net.Listener, error) {
 	switch parsed.Scheme {
 	case "vsock":
 		svcid, err := hvsock.GUIDFromString(parsed.Hostname())
@@ -25,11 +20,7 @@ func Listen(endpoint string) (net.Listener, error) {
 			VMID:      hvsock.GUIDWildcard,
 			ServiceID: svcid,
 		})
-	case "unix":
-		return net.Listen(parsed.Scheme, parsed.Path)
-	case "tcp":
-		return net.Listen("tcp", parsed.Host)
 	default:
-		return nil, errors.New("unexpected scheme")
+		return defaultListenURL(parsed)
 	}
 }

--- a/pkg/transport/unixgram_darwin.go
+++ b/pkg/transport/unixgram_darwin.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build darwin
+// +build darwin
 
 package transport
 

--- a/pkg/transport/unixgram_nondarwin.go
+++ b/pkg/transport/unixgram_nondarwin.go
@@ -1,0 +1,17 @@
+//go:build !darwin
+// +build !darwin
+
+package transport
+
+import (
+	"errors"
+	"net"
+)
+
+func ListenUnixgram(_ string) (net.Conn, error) {
+	return nil, errors.New("unsupported 'unixgram' scheme")
+}
+
+func AcceptVfkit(_ net.Conn) (net.Conn, error) {
+	return nil, errors.New("vfkit is unsupported on this platform")
+}


### PR DESCRIPTION
The end goal is to be able to build it on !linux, !darwin, !windows platforms (eg bsd platforms)

This is an opportunity to separate the generic code (URL parsing, listen()
for unix and tcp) which can always be built from the platform-specific code.