### PR TITLE
Packit: reuse copr targets for podman-next

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,7 +17,7 @@ jobs:
     trigger: pull_request
     enable_net: true
     # keep in sync with https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next
-    targets:
+    targets: &copr_targets
       - fedora-rawhide-aarch64
       - fedora-rawhide-x86_64
       - fedora-eln-aarch64
@@ -38,6 +38,7 @@ jobs:
     branch: main
     owner: rhcontainerbot
     project: podman-next
+    targets: *copr_targets
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
Fedora 37 is already disabled on the podman-next copr for this package
but that setting doesn't seem to be honoured atm.
    
This commit reuses copr targets so builds for f37 are disabled via
packit.
