### PR TITLE
Packit: enable f39 targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,6 +22,8 @@ jobs:
       - fedora-rawhide-x86_64
       - fedora-eln-aarch64
       - fedora-eln-x86_64
+      - fedora-39-aarch64
+      - fedora-39-x86_64
       - fedora-38-aarch64
       - fedora-38-x86_64
       - centos-stream+epel-next-8-x86_64


### PR DESCRIPTION
The target specification will become a lot simpler once f37 goes EOL.