### PR TITLE
build: Use ldflags in win-{gvproxy,sshproxy} targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,29 +7,29 @@ build: gvproxy qemu-wrapper vm
 TOOLS_DIR := tools
 include tools/tools.mk
 
-LDFLAGS = -ldflags '-s -w'
+LDFLAGS = -s -w
 
 .PHONY: gvproxy
 gvproxy:
-	go build $(LDFLAGS) -o bin/gvproxy ./cmd/gvproxy
+	go build -ldflags "$(LDFLAGS)" -o bin/gvproxy ./cmd/gvproxy
 
 .PHONY: qemu-wrapper
 qemu-wrapper:
-	go build $(LDFLAGS) -o bin/qemu-wrapper ./cmd/qemu-wrapper
+	go build -ldflags "$(LDFLAGS)" -o bin/qemu-wrapper ./cmd/qemu-wrapper
 
 .PHONY: vm
 vm:
-	GOOS=linux CGO_ENABLED=0 go build $(LDFLAGS) -o bin/gvforwarder ./cmd/vm
+	GOOS=linux CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/gvforwarder ./cmd/vm
 
 # win-sshproxy is compiled as a windows GUI to support backgrounding
 .PHONY: win-sshproxy
 win-sshproxy:
-	GOOS=windows go build -ldflags -H=windowsgui -o bin/win-sshproxy.exe ./cmd/win-sshproxy
+	GOOS=windows go build -ldflags "$(LDFLAGS) -H=windowsgui" -o bin/win-sshproxy.exe ./cmd/win-sshproxy
 
 # gvproxy for windows is compiled as a windows GUI to support backgrounding
 .PHONY: win-gvproxy
 win-gvproxy:
-	GOOS=windows go build -ldflags -H=windowsgui -o bin/gvproxy.exe ./cmd/gvproxy
+	GOOS=windows go build -ldflags "$(LDFLAGS) -H=windowsgui" -o bin/gvproxy.exe ./cmd/gvproxy
 
 .PHONY: clean
 clean:
@@ -50,17 +50,17 @@ image:
 
 .PHONY: cross
 cross: $(TOOLS_BINDIR)/makefat
-	GOARCH=amd64 GOOS=freebsd  go build $(LDFLAGS) -o bin/gvproxy-freebsd-amd64 ./cmd/gvproxy
-	GOARCH=amd64 GOOS=windows go build $(LDFLAGS) -o bin/gvproxy-windows.exe ./cmd/gvproxy
-	GOARCH=amd64 GOOS=linux   go build $(LDFLAGS) -o bin/gvproxy-linux-amd64 ./cmd/gvproxy
-	GOARCH=arm64 GOOS=linux   go build $(LDFLAGS) -o bin/gvproxy-linux-arm64 ./cmd/gvproxy
-	GOARCH=amd64 GOOS=darwin  go build $(LDFLAGS) -o bin/gvproxy-darwin-amd64 ./cmd/gvproxy
-	GOARCH=arm64 GOOS=darwin  go build $(LDFLAGS) -o bin/gvproxy-darwin-arm64 ./cmd/gvproxy
+	GOARCH=amd64 GOOS=freebsd  go build -ldflags "$(LDFLAGS)" -o bin/gvproxy-freebsd-amd64 ./cmd/gvproxy
+	GOARCH=amd64 GOOS=windows go build -ldflags "$(LDFLAGS)" -o bin/gvproxy-windows.exe ./cmd/gvproxy
+	GOARCH=amd64 GOOS=linux   go build -ldflags "$(LDFLAGS)" -o bin/gvproxy-linux-amd64 ./cmd/gvproxy
+	GOARCH=arm64 GOOS=linux   go build -ldflags "$(LDFLAGS)" -o bin/gvproxy-linux-arm64 ./cmd/gvproxy
+	GOARCH=amd64 GOOS=darwin  go build -ldflags "$(LDFLAGS)" -o bin/gvproxy-darwin-amd64 ./cmd/gvproxy
+	GOARCH=arm64 GOOS=darwin  go build -ldflags "$(LDFLAGS)" -o bin/gvproxy-darwin-arm64 ./cmd/gvproxy
 	cd bin && $(TOOLS_BINDIR)/makefat gvproxy-darwin gvproxy-darwin-amd64 gvproxy-darwin-arm64 && rm gvproxy-darwin-amd64 gvproxy-darwin-arm64
 
 .PHONY: test-companion
 test-companion:
-	GOOS=linux go build $(LDFLAGS) -o bin/test-companion ./cmd/test-companion
+	GOOS=linux go build -ldflags "$(LDFLAGS)" -o bin/test-companion ./cmd/test-companion
 
 .PHONY: test
 test: gvproxy test-companion


### PR DESCRIPTION
The windowsgui binary is currently 50% bigger than its non-windowsgui
counterpart. This size difference is gone when win-gvproxy is built with
'-s -w' as the other binaries.