### PR TITLE
transport: Support passing CID for linux vsock

### DIFF
--- a/pkg/transport/listen_linux.go
+++ b/pkg/transport/listen_linux.go
@@ -17,6 +17,15 @@ func listenURL(parsed *url.URL) (net.Listener, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if parsed.Hostname() != "" {
+			cid, err := strconv.Atoi(parsed.Hostname())
+			if err != nil {
+				return nil, err
+			}
+			return mdlayhervsock.ListenContextID(uint32(cid), uint32(port), nil)
+		}
+
 		return mdlayhervsock.Listen(uint32(port), nil)
 	case "unixpacket":
 		return net.Listen(parsed.Scheme, parsed.Path)


### PR DESCRIPTION
Support passing the vsock CID explicitly as part of the listener address. This can be particularly useful in containerized environments where the `/dev/vsock` device is not available to lookup the CID.

In particular, we ran into this when trying to use `gvproxy` with AWS Nitro Enclaves on Kubernetes.