### PR TITLE
Add --version argument to commands

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/pkg/types/version.go export-subst

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 TAG ?= $(shell git describe --match=NeVeRmAtCh --always --abbrev=40 --dirty)
+GIT_VERSION ?= $(shell git describe --always --dirty)
 CONTAINER_RUNTIME ?= podman
 
 .PHONY: build
@@ -7,7 +8,8 @@ build: gvproxy qemu-wrapper vm
 TOOLS_DIR := tools
 include tools/tools.mk
 
-LDFLAGS = -s -w
+VERSION_LDFLAGS=-X github.com/containers/gvisor-tap-vsock/pkg/types.gitVersion=$(GIT_VERSION)
+LDFLAGS = -s -w $(VERSION_LDFLAGS)
 
 .PHONY: gvproxy
 gvproxy:

--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -56,6 +56,8 @@ const (
 )
 
 func main() {
+	version := types.NewVersion("gvproxy")
+	version.AddFlag()
 	flag.Var(&endpoints, "listen", "control endpoint")
 	flag.BoolVar(&debug, "debug", false, "Print debug info")
 	flag.IntVar(&mtu, "mtu", 1500, "Set the MTU")
@@ -72,6 +74,12 @@ func main() {
 	flag.StringVar(&pidFile, "pid-file", "", "Generate a file with the PID in it")
 	flag.Parse()
 
+	if version.ShowVersion() {
+		fmt.Println(version.String())
+		os.Exit(0)
+	}
+
+	log.Infof(version.String())
 	ctx, cancel := context.WithCancel(context.Background())
 	// Make this the last defer statement in the stack
 	defer os.Exit(exitCode)

--- a/cmd/ssh-over-vsock/main.go
+++ b/cmd/ssh-over-vsock/main.go
@@ -4,8 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/transport"
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -19,12 +21,19 @@ var (
 )
 
 func main() {
+	version := types.NewVersion("ssh-over-vsock")
+	version.AddFlag()
 	flag.StringVar(&ip, "ip", "192.168.127.2", "ip of the host")
 	flag.IntVar(&port, "port", 22, "port of the host")
 	flag.StringVar(&user, "user", "", "ssh user")
 	flag.StringVar(&key, "key", "", "ssh key")
 	flag.StringVar(&endpoint, "url", "/tmp/network.sock", "url of the daemon")
 	flag.Parse()
+
+	if version.ShowVersion() {
+		fmt.Println(version.String())
+		os.Exit(0)
+	}
 
 	if err := run(); err != nil {
 		logrus.Fatal(err)

--- a/cmd/vm/main_linux.go
+++ b/cmd/vm/main_linux.go
@@ -35,6 +35,8 @@ var (
 )
 
 func main() {
+	version := types.NewVersion("gvforwarder")
+	version.AddFlag()
 	flag.StringVar(&endpoint, "url", fmt.Sprintf("vsock://2:1024%s", types.ConnectPath), "url where the tap send packets")
 	flag.StringVar(&iface, "iface", "tap0", "tap interface name")
 	flag.StringVar(&stopIfIfaceExist, "stop-if-exist", "eth0,ens3,enp0s1", "stop if one of these interfaces exists at startup")
@@ -43,6 +45,11 @@ func main() {
 	flag.IntVar(&mtu, "mtu", 4000, "mtu")
 	flag.BoolVar(&tapPreexists, "preexisting", false, "use preexisting/preconfigured TAP interface")
 	flag.Parse()
+
+	if version.ShowVersion() {
+		fmt.Println(version.String())
+		os.Exit(0)
+	}
 
 	expected := strings.Split(stopIfIfaceExist, ",")
 	links, err := netlink.LinkList()

--- a/cmd/win-sshproxy/main.go
+++ b/cmd/win-sshproxy/main.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/sshclient"
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/containers/winquit/pkg/winquit"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -33,10 +34,15 @@ var (
 func main() {
 	args := os.Args
 	if len(args) > 1 {
-		if args[1] == "-debug" {
+		switch args[1] {
+		case "-version":
+			version := types.NewVersion("win-sshproxy")
+			fmt.Println(version.String())
+			os.Exit(0)
+		case "-debug":
 			debug = true
 			args = args[2:]
-		} else {
+		default:
 			args = args[1:]
 		}
 	}

--- a/pkg/types/version.go
+++ b/pkg/types/version.go
@@ -4,11 +4,15 @@ import (
 	"flag"
 	"fmt"
 	"runtime/debug"
+	"strings"
 )
 
 var (
 	// set using the '-X github.com/containers/gvisor-tap-vsock/pkg/types.gitVersion' linker flag
 	gitVersion = ""
+	// set through .gitattributes when `git archive` is used
+	// see https://icinga.com/blog/2022/05/25/embedding-git-commit-information-in-go-binaries/
+	gitArchiveVersion = "$Format:%(describe)$"
 )
 
 type version struct {
@@ -36,6 +40,9 @@ func (ver *version) ShowVersion() bool {
 
 func moduleVersion() string {
 	switch {
+	// This will be substituted when building from a GitHub tarball
+	case !strings.HasPrefix(gitArchiveVersion, "$Format:"):
+		return gitArchiveVersion
 	// This will be set when building from git using make
 	case gitVersion != "":
 		return gitVersion

--- a/pkg/types/version.go
+++ b/pkg/types/version.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"flag"
+	"fmt"
+)
+
+var (
+	// set using the '-X github.com/containers/gvisor-tap-vsock/pkg/types.gitVersion' linker flag
+	gitVersion = ""
+)
+
+type version struct {
+	binaryName  string
+	showVersion bool
+}
+
+func NewVersion(binaryName string) *version { //nolint:revive
+	return &version{
+		binaryName: binaryName,
+	}
+}
+
+func (ver *version) String() string {
+	return fmt.Sprintf("%s version %s", ver.binaryName, gitVersion)
+}
+
+func (ver *version) AddFlag() {
+	flag.BoolVar(&ver.showVersion, "version", false, "Print version information")
+}
+
+func (ver *version) ShowVersion() bool {
+	return ver.showVersion
+}

--- a/pkg/types/version.go
+++ b/pkg/types/version.go
@@ -3,6 +3,7 @@ package types
 import (
 	"flag"
 	"fmt"
+	"runtime/debug"
 )
 
 var (
@@ -22,7 +23,7 @@ func NewVersion(binaryName string) *version { //nolint:revive
 }
 
 func (ver *version) String() string {
-	return fmt.Sprintf("%s version %s", ver.binaryName, gitVersion)
+	return fmt.Sprintf("%s version %s", ver.binaryName, moduleVersion())
 }
 
 func (ver *version) AddFlag() {
@@ -31,4 +32,26 @@ func (ver *version) AddFlag() {
 
 func (ver *version) ShowVersion() bool {
 	return ver.showVersion
+}
+
+func moduleVersion() string {
+	switch {
+	// This will be set when building from git using make
+	case gitVersion != "":
+		return gitVersion
+	// moduleVersionFromBuildInfo() will be set when using `go install`
+	default:
+		return moduleVersionFromBuildInfo()
+	}
+}
+
+func moduleVersionFromBuildInfo() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	if info.Main.Version == "(devel)" {
+		return ""
+	}
+	return info.Main.Version
 }

--- a/rpm/gvisor-tap-vsock.spec
+++ b/rpm/gvisor-tap-vsock.spec
@@ -92,8 +92,8 @@ CGO_CFLAGS=$(echo $CGO_CFLAGS | sed 's/-specs=\/usr\/lib\/rpm\/redhat\/redhat-an
 export CGO_CFLAGS+=" -m64 -mtune=generic -fcf-protection=full"
 %endif
 
-# reset LDFLAGS for plugins and gvisor binaries
-LDFLAGS=''
+# reset LDFLAGS for plugins and gvisor binaries, but ensure gvproxy --version and such is set
+LDFLAGS="-X github.com/containers/gvisor-tap-vsock/pkg/types.gitVersion=%{version}"
 
 # build gvisor-tap-vsock binaries
 %gobuild -o bin/gvproxy ./cmd/gvproxy

--- a/rpm/gvisor-tap-vsock.spec
+++ b/rpm/gvisor-tap-vsock.spec
@@ -92,8 +92,8 @@ CGO_CFLAGS=$(echo $CGO_CFLAGS | sed 's/-specs=\/usr\/lib\/rpm\/redhat\/redhat-an
 export CGO_CFLAGS+=" -m64 -mtune=generic -fcf-protection=full"
 %endif
 
-# reset LDFLAGS for plugins and gvisor binaries, but ensure gvproxy --version and such is set
-LDFLAGS="-X github.com/containers/gvisor-tap-vsock/pkg/types.gitVersion=%{version}"
+# reset LDFLAGS for plugins and gvisor binaries
+LDFLAGS=''
 
 # build gvisor-tap-vsock binaries
 %gobuild -o bin/gvproxy ./cmd/gvproxy


### PR DESCRIPTION
The binaries shipped by gvisor-tap-vsock don't have a --version argument.
This is problematic to check which version is being used (for example, podman ships different gvproxy versions if it comes from brew or an installer, if it's running on macOS or Windows).
This PR adds --version to commands which accept arguments.
It's a bit involved as I wanted --version to work:
- when building from git
- when building from a github tarball
- when installing through go install

This unfortunately requires 3 different codepaths, but it works in these 3 cases.