### PR TITLE
Add log-file to proxy builder

### DIFF
--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -95,6 +95,12 @@ func main() {
 			}
 		}()
 		log.SetOutput(lf)
+
+		// If debug is set, lets seed the log file with some basic information
+		// about the environment and how it was called
+		log.Debugf("gvproxy version: %q", version.String())
+		log.Debugf("os: %q arch: %q", runtime.GOOS, runtime.GOARCH)
+		log.Debugf("command line: %q", os.Args)
 	}
 
 	log.Infof(version.String())

--- a/pkg/types/gvproxy_command.go
+++ b/pkg/types/gvproxy_command.go
@@ -22,6 +22,9 @@ type GvproxyCommand struct {
 	// Map of different sockets provided by user (socket-type flag:socket)
 	sockets map[string]string
 
+	// Logfile where gvproxy should redirect logs
+	LogFile string
+
 	// File where gvproxy's pid is stored
 	PidFile string
 
@@ -177,6 +180,11 @@ func (c *GvproxyCommand) ToCmdline() []string {
 	// pid-file
 	if c.PidFile != "" {
 		args = append(args, "-pid-file", c.PidFile)
+	}
+
+	// log-file
+	if c.LogFile != "" {
+		args = append(args, "-log-file", c.LogFile)
 	}
 
 	return args

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -204,6 +204,7 @@ var _ = ginkgo.Describe("command-line format", func() {
 		command.Debug = true
 		command.AddQemuSocket("tcp://0.0.0.0:1234")
 		command.PidFile = "~/gv-pidfile.txt"
+		command.LogFile = "~/gv.log"
 		command.AddForwardUser("demouser")
 
 		cmd := command.ToCmdline()
@@ -215,6 +216,7 @@ var _ = ginkgo.Describe("command-line format", func() {
 			"-listen-qemu", "tcp://0.0.0.0:1234",
 			"-forward-user", "demouser",
 			"-pid-file", "~/gv-pidfile.txt",
+			"-log-file", "~/gv.log",
 		}))
 	})
 })


### PR DESCRIPTION
The original PR only enabled log-file on the command line.  This PR adds log-file to gvproxy's builder (for consumption) and adds trivial test.