### PR TITLE
gh: Fix 'if:' statement to avoid multiple uploads

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
         mv bin/gvproxy.exe bin/gvproxy-windowsgui.exe
 
     - uses: actions/upload-artifact@v4
-      if: ${{ matrix.go-version }} == '1.21.x'
+      if: matrix.go-version == '1.21.x'
       with:
         name: gvisor-tap-vsock-binaries
         path: bin/*

--- a/OWNERS
+++ b/OWNERS
@@ -5,4 +5,5 @@ approvers:
 reviewers:
   - baude
   - cfergeau
+  - jakecorrenti
   - praveenkumar


### PR DESCRIPTION
`actions/upload-artifact` will fail if we try to upload multiple times
the same artifact, which can happen in our setup with the matrix of go
versions:
```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

I tried to fix this before, but I got the `if:` condition wrong in the
workflow YAML file:
`if: matrix.go-version == '1.21.x'` should work better than `if: ${{ matrix.go-version }} == '1.21.x'`