### PR TITLE
Add DNS '8.8.8.8' server to use in test

### DIFF
--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("dns", func() {
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("wikipedia.org	nameserver = ns0.wikimedia.org."))
 	})
 	ginkgo.It("should resolve LDAP SRV record for google.com", func() {
-		out, err := sshExec("nslookup -query=srv _ldap._tcp.google.com")
+		out, err := sshExec("nslookup -query=srv _ldap._tcp.google.com 8.8.8.8")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring(`_ldap._tcp.google.com	service = 5 0 389 ldap.google.com.`))
 	})


### PR DESCRIPTION
In GH Action, sometime, DNS server return compressed response, which is not comply with RFS, so go is unable to parse response.

This PR is force to use `8.8.8.8` DNS server.