### PR TITLE
test: Use ubuntu runner instead of macos runner for tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,16 +38,16 @@ jobs:
         path: bin/*
 
   tests:
-    runs-on: macos-latest # Only Mac runners support nested virt
+    runs-on: ubuntu-latest # The runner must support nested virt
     needs: build # Don't bother testing if cross arch build fails
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install
+    - name: Install qemu
       run: |
-        brew install qemu
-        touch continue
+        sudo apt install qemu-kvm
+        sudo usermod -a -G kvm $USER
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -55,7 +55,8 @@ jobs:
         go-version-file: 'go.mod'
 
     - name: Test
-      run: make test
+      run: |
+        sudo -s -u ${USER} bash -c 'make test'
 
     - uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
+        go-version-file: 'go.mod'
 
     - name: Test
       run: make test
@@ -72,12 +72,12 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
+        go-version-file: 'go.mod'
 
-    - name: Build 
+    - name: Build
       run: make win-sshproxy
 
-    - name: Test 
+    - name: Test
       run: go test -v .\test-win-sshproxy
 
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.20.x", "1.21.x", "1.22.0-rc.1"]
+        go-version: ["1.20.x", "1.21.x", "1.22.x"]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,11 +11,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
-
-      - uses: actions/checkout@v4
+          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Set up Go
       uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
 
     - name: Build
       run: |

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -162,10 +162,11 @@ func qemuExecutable() string {
 }
 
 func qemuArgs() string {
+	accel := "kvm"
 	if runtime.GOOS == "darwin" {
-		return "-machine q35,accel=hvf:tcg -smp 4 -cpu host"
+		accel = "hvf"
 	}
-	return "-cpu host"
+	return fmt.Sprintf("-machine q35,accel=%s:tcg -smp 4 -cpu host", accel)
 }
 
 func createSSHKeys() (string, error) {

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -150,10 +150,15 @@ outer:
 })
 
 func qemuExecutable() string {
-	if runtime.GOOS == "darwin" {
-		return "qemu-system-x86_64"
+	qemuBinaries := []string{"qemu-kvm", "qemu-system-x86_64"}
+	for _, binary := range qemuBinaries {
+		path, err := exec.LookPath(binary)
+		if err == nil && path != "" {
+			return path
+		}
 	}
-	return "qemu-kvm"
+
+	return ""
 }
 
 func qemuArgs() string {


### PR DESCRIPTION
M1 macos runners can't build our test code, and the M1 runners don't 
support nested virt, which is required by `make test` Since I expect in the
future the x86_64 macos runners to go away, and since the ubuntu runners
now support nested virt, this commit uses an ubuntu runner to run `make
test`.