### PR TITLE
Fix Unix URL handling in ssh_forwarder

### DIFF
--- a/pkg/sshclient/ssh_forwarder.go
+++ b/pkg/sshclient/ssh_forwarder.go
@@ -7,8 +7,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -111,18 +109,13 @@ func connectForward(ctx context.Context, bastion *Bastion) (CloseWriteConn, erro
 }
 
 func listenUnix(socketURI *url.URL) (net.Listener, error) {
-	path := socketURI.Path
-	if runtime.GOOS == "windows" {
-		path = strings.TrimPrefix(path, "/")
-	}
-
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(socketURI.Path); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 
 	oldmask := fs.Umask(0177)
 	defer fs.Umask(oldmask)
-	listener, err := net.Listen("unix", path)
+	listener, err := net.Listen("unix", socketURI.Path)
 	if err != nil {
 		return listener, errors.Wrapf(err, "Error listening on socket: %s", socketURI.Path)
 	}


### PR DESCRIPTION
Fixes #371 

This platform specific handling seems not to do what it was originally intended to. See details in the original issue.