### PR TITLE
Fix OS specific url handling for unix:// scheme in transport

### DIFF
--- a/pkg/transport/listen.go
+++ b/pkg/transport/listen.go
@@ -4,12 +4,18 @@ import (
 	"errors"
 	"net"
 	"net/url"
+	"runtime"
+	"strings"
 )
 
 func defaultListenURL(url *url.URL) (net.Listener, error) {
 	switch url.Scheme {
 	case "unix":
-		return net.Listen(url.Scheme, url.Path)
+		path := url.Path
+		if runtime.GOOS == "windows" {
+			path = strings.TrimPrefix(path, "/")
+		}
+		return net.Listen(url.Scheme, path)
 	case "tcp":
 		return net.Listen("tcp", url.Host)
 	default:


### PR DESCRIPTION
Fixes #371 

Replaces #372 

Details why it changed in https://github.com/containers/gvisor-tap-vsock/issues/371#issuecomment-2244689107

This adds handling for `unix://` scheme under Windows with absolute path (containing drive letter). This replicates the one from ssh_forwarder (https://github.com/containers/gvisor-tap-vsock/blob/6dbbe087eb62775e99abc69ac232d13f74cac73a/pkg/sshclient/ssh_forwarder.go#L114).

Test command:

```bat
gvproxy.exe -debug -mtu 1500 -ssh-port 50402 -listen-qemu unix:///C:/Users/Arthu/AppData/Local/Temp/podman/podman-machine-default-gvproxy.sock -forward-sock unix:///C:/Users/Arthu/AppData/Local/Temp/podman/podman-machine-default-api.sock -forward-dest /run/user/1000/podman/podman.sock -forward-user core -forward-identity C:\\Users\\Arthu\\.local\\share\\containers\\podman\\machine\\machine -pid-file C:\\Users\\Arthu\\AppData\\Local\\Temp\\podman\\gvproxy.pid
```