### PR TITLE
ghactions: Automatically create gh releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,12 @@ jobs:
       with:
         name: gvisor-tap-vsock-binaries
         path: bin/*
+
+    - name: Create release on github
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+          gh release create --draft --generate-notes --verify-tag ${{github.ref_name}}
+          cd bin
+          sha256sum * >> sha256sums
+          gh release upload ${{github.ref_name}} *


### PR DESCRIPTION
This commit uses the 'gh' command line tool to create a new draft github
release and upload the gvproxy* binaries to it.
It's triggered on v* tag pushes.