### PR TITLE
Revert MacOS regression introduced in 600910caefc729efaaae16219be51d081284a104

### DIFF
--- a/vendor/github.com/inetaf/tcpproxy/tcpproxy.go
+++ b/vendor/github.com/inetaf/tcpproxy/tcpproxy.go
@@ -401,10 +401,9 @@ func (dp *DialProxy) HandleConn(src net.Conn) {
 		}
 	}
 
-	errc := make(chan error, 2)
+	errc := make(chan error, 1)
 	go proxyCopy(errc, src, dst)
 	go proxyCopy(errc, dst, src)
-	<-errc
 	<-errc
 }
 


### PR DESCRIPTION
On MacOS, gvproxy 0.7.4 does not close connections properly, leading to resource exhaustion over time.

Original issue reported in podman here:

https://github.com/containers/podman/issues/23616