### PR TITLE
Fix consistent udp packet loss after the proxy read loop stopped

### DIFF
--- a/pkg/services/forwarder/udp.go
+++ b/pkg/services/forwarder/udp.go
@@ -38,6 +38,13 @@ func UDP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mute
 		p, _ := NewUDPProxy(&autoStoppingListener{underlying: gonet.NewUDPConn(s, &wq, ep)}, func() (net.Conn, error) {
 			return net.Dial("udp", fmt.Sprintf("%s:%d", localAddress, r.ID().LocalPort))
 		})
-		go p.Run()
+		go func() {
+			p.Run()
+
+			// note that at this point packets that are sent to the current forwarder session
+			// will be dropped. We will start processing the packets again when we get a new
+			// forwarder request.
+			ep.Close()
+		}()
 	})
 }


### PR DESCRIPTION
Currently we never close the `tcpip.Endpoint` that we created when we get `*udp.ForwarderRequest`. This causes all packets that is sent by the same src ip:port after we return from the `UDPProxy.Run` to be "dropped". 

By closing the endpoint, we will get new forwarder request after we return from `UDPProxy.Run` so we can process new packets.

Here's my reproduction code:
1. Reuse the same local address when sending udp requests
2. Send one DNS request (success)
3. wait until `UDPProxy.Run` to return (after 90s)
4. Send one DNS request (failed)

```go
package main

import (
	"context"
	"fmt"
	"net"
	"time"
)

func main() {
	r := &net.Resolver{
		PreferGo: true,
		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
			addr, err := net.ResolveUDPAddr("udp", "192.168.5.1:40001")
			if err != nil {
				panic(err)
			}

			d := net.Dialer{
				Timeout:   time.Millisecond * time.Duration(10000),
				KeepAlive: -1,
				LocalAddr: addr,
			}

			conn, err := d.DialContext(ctx, network, "8.8.8.8:53")
			if err != nil {
				panic(err)
			}

			return conn, err
		},
	}

	lookup := func() {
		_, err := r.LookupIP(context.Background(), "ip4", "www.google.com")
		if err != nil {
			fmt.Println("err", err)
		} else {
			fmt.Println("ok")
		}
	}

	lookup()                     // ok
	time.Sleep(95 * time.Second) // wait for the UDPConnTimeout
	lookup()                     // this will fail
}

```