### PR TITLE
packit: Don't attempt to build on f39

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.21.x", "1.22.x"]
+        go-version: ["1.22.x", "1.23.x"]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -32,7 +32,7 @@ jobs:
         mv bin/gvproxy.exe bin/gvproxy-windowsgui.exe
 
     - uses: actions/upload-artifact@v4
-      if: matrix.go-version == '1.21.x'
+      if: matrix.go-version == '1.22.x'
       with:
         name: gvisor-tap-vsock-binaries
         path: bin/*

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,8 +25,12 @@ jobs:
     packages: [gvisor-tap-vsock-fedora]
     enable_net: true
     targets:
-      - fedora-all-aarch64
-      - fedora-all-x86_64
+      - fedora-development-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-stable-x86_64
+      - fedora-latest-stable-aarch64
+      - fedora-40-x86_64
+      - fedora-40-aarch64
       - fedora-eln-aarch64
       - fedora-eln-x86_64
 
@@ -54,7 +58,9 @@ jobs:
     packages: [gvisor-tap-vsock-fedora]
     update_release: false
     dist_git_branches:
-      - fedora-all
+      - fedora-development
+      - fedora-latest-stable
+      - fedora-40
 
   - job: propose_downstream
     trigger: release
@@ -67,10 +73,14 @@ jobs:
     trigger: commit
     packages: [gvisor-tap-vsock-fedora]
     dist_git_branches:
-      - fedora-all
+      - fedora-development
+      - fedora-latest-stable
+      - fedora-40
 
   - job: bodhi_update
     trigger: commit
     packages: [gvisor-tap-vsock-fedora]
     dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically
+      - fedora-latest # rawhide updates are created automatically
+      - fedora-latest-stable
+      - fedora-40


### PR DESCRIPTION
It only has go 1.21 while we switched to go 1.22, so gvisor-tap-vsock
fails to build on f39.
I don't expect significant changes to gvisor-tap-vsock during the
remaining f39 lifetime, at worse podman in f39 can keep using an older
gvproxy release.