### PR TITLE
Disable ssh port forwarding when value of -ssh-port is -1

### DIFF
--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -167,7 +167,7 @@ func main() {
 
 	// If the given port is not between the privileged ports
 	// and the oft considered maximum port, return an error.
-	if sshPort < 1024 || sshPort > 65535 {
+	if sshPort != -1 && sshPort < 1024 || sshPort > 65535 {
 		exitWithError(errors.New("ssh-port value must be between 1024 and 65535"))
 	}
 	protocol := types.HyperKitProtocol
@@ -250,9 +250,7 @@ func main() {
 			},
 		},
 		DNSSearchDomains: searchDomains(),
-		Forwards: map[string]string{
-			fmt.Sprintf("127.0.0.1:%d", sshPort): sshHostPort,
-		},
+		Forwards:         getForwardsMap(sshPort, sshHostPort),
 		NAT: map[string]string{
 			hostIP: "127.0.0.1",
 		},
@@ -282,6 +280,15 @@ func main() {
 	if err := groupErrs.Wait(); err != nil {
 		log.Errorf("gvproxy exiting: %v", err)
 		exitCode = 1
+	}
+}
+
+func getForwardsMap(sshPort int, sshHostPort string) map[string]string {
+	if sshPort == -1 {
+		return map[string]string{}
+	}
+	return map[string]string{
+		fmt.Sprintf("127.0.0.1:%d", sshPort): sshHostPort,
 	}
 }
 


### PR DESCRIPTION
This is a fix for https://github.com/containers/gvisor-tap-vsock/issues/402

The default value for the flag is `2222` which should not happen when `-1` is provided.

Tested as follows:

```
gvyas@Gunjans-MacBook-Pro gvisor-tap-vsock % bin/gvproxy -debug -listen unix:///tmp/network.sock -listen-qemu tcp://0.0.0.0:1234 -ssh-port 55556
INFO[0000] gvproxy version gitd1683b9b-dirty
INFO[0000] waiting for clients...
INFO[0000] listening unix:///tmp/network.sock


gvyas@Gunjans-MacBook-Pro gvisor-tap-vsock % lsof -i :55556
COMMAND   PID  USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
gvproxy 60527 gvyas    7u  IPv4 0xef6992879c346520      0t0  TCP localhost:55556 (LISTEN)
```

```
gvyas@Gunjans-MacBook-Pro gvisor-tap-vsock % bin/gvproxy -debug -listen unix:///tmp/network.sock -listen-qemu tcp://0.0.0.0:1234
INFO[0000] gvproxy version gitd1683b9b-dirty
INFO[0000] waiting for clients...
INFO[0000] listening unix:///tmp/network.sock


gvyas@Gunjans-MacBook-Pro gvisor-tap-vsock % lsof -i :2222
COMMAND   PID  USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
gvproxy 60743 gvyas    7u  IPv4 0xb6a79b454352e9f5      0t0  TCP localhost:rockwell-csp2 (LISTEN)
```

```
gvyas@Gunjans-MacBook-Pro gvisor-tap-vsock % bin/gvproxy -debug -listen unix:///tmp/network.sock -listen-qemu tcp://0.0.0.0:1234 -ssh-port -1
INFO[0000] gvproxy version gitd1683b9b-dirty
INFO[0000] waiting for clients...
INFO[0000] listening unix:///tmp/network.sock


gvyas@Gunjans-MacBook-Pro gvisor-tap-vsock % lsof -i :2222
gvyas@Gunjans-MacBook-Pro gvisor-tap-vsock %
```