### PR TITLE
Add --services flag to start API without using --listen flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ With the executable:
 
 ### API
 
-When `gvproxy` is started with the `--listen` option, it exposes a HTTP API on the host.
+When `gvproxy` is started with the `--listen` or `--services` option, it exposes a HTTP API on the host.
 This API can be used with curl.
 
 ```
@@ -126,6 +126,8 @@ $ curl  --unix-socket /tmp/network.sock http:/unix/stats
   "MalformedRcvdPackets": 0,
 ...
 ```
+
+N.B: The `--services` option exposes the same HTTP API as the `--listen` option, but without the `/connect` endpoint. This is useful for scenarios where the `gvforwarder`/`vm` tool is not run on the guest but you still want to expose services and stats endpoints.
 
 ### Gateway
 
@@ -144,7 +146,7 @@ nameserver 192.168.127.1
 ### Port forwarding
 
 Dynamic port forwarding is supported over the host HTTP API when `gvproxy` was
-started with `--listen`, but also in the VM over http://192.168.127.1:80.
+started with `--listen` or `--services`, but also in the VM over http://192.168.127.1:80.
 
 Expose a port:
 ```


### PR DESCRIPTION
In the current implementation when gvproxy is started with the --listen option, it exposes a HTTP API with several endpoints like /connect, /stats, /services ...
The /connect endpoint, however, is only used when the gvforwarder tool is running on the guest, and, when using different connectivities like --listen-vfkit or --listen-qemu, it is not really necessary.

This commit adds a new flag --services that allows to start the HTTP API without the /connect endpoint. 

I was not sure how to implement it as I saw 3 possible use cases:
1) add it as a boolean flag (e.g. --enable-services) and when true creating an endpoint using a defaultURL having a defined http API (the same as --listen, except for the `/connect` endpoint)
2) using an array flag (e.g. --api-endpoints) so that the user could specify the endpoint he/she wanted to enable, like --api-endpoints stats, services,connect
3) the current implementation. A string flag (--services) which works how the other options. The user specify the endpoint and the http api gets started (the same as --listen, except for the `/connect` endpoint)

I went with the third to stick with the same behavior but open to discuss.

I'll add some test in a follow-up PR as I'd like to leverage the code from https://github.com/containers/gvisor-tap-vsock/pull/427