### PR TITLE
win-sshproxy.tid created before thread id is available

### DIFF
--- a/pkg/utils/retry.go
+++ b/pkg/utils/retry.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const maxRetries = 60
+const initialBackoff = 100 * time.Millisecond
+
+func Retry[T comparable](ctx context.Context, retryFunc func() (T, error), retryMsg string) (T, error) {
+	var (
+		returnVal T
+		err       error
+	)
+
+	backoff := initialBackoff
+
+loop:
+	for i := 0; i < maxRetries; i++ {
+		select {
+		case <-ctx.Done():
+			break loop
+		default:
+			// proceed
+		}
+
+		returnVal, err = retryFunc()
+		if err == nil {
+			return returnVal, nil
+		}
+		logrus.Debugf("%s (%s)", retryMsg, backoff)
+		Sleep(ctx, backoff)
+		backoff = backOff(backoff)
+	}
+	return returnVal, fmt.Errorf("timeout: %w", err)
+}
+
+func backOff(delay time.Duration) time.Duration {
+	if delay == 0 {
+		delay = 5 * time.Millisecond
+	} else {
+		delay *= 2
+	}
+	if delay > time.Second {
+		delay = time.Second
+	}
+	return delay
+}
+
+func Sleep(ctx context.Context, wait time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(wait):
+		return true
+	}
+}

--- a/test-win-sshproxy/basic_test.go
+++ b/test-win-sshproxy/basic_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package e2e
@@ -25,15 +26,16 @@ var _ = Describe("connectivity", func() {
 		err := startProxy()
 		Expect(err).ShouldNot(HaveOccurred())
 
-		var pid uint32
+		var pid, tid uint32
 		for i := 0; i < 20; i++ {
-			pid, _, err = readTid()
-			if err == nil {
+			pid, tid, err = readTid()
+			if err == nil && tid != 0 {
 				break
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
 
+		Expect(tid).ShouldNot(Equal(0))
 		Expect(err).ShouldNot(HaveOccurred())
 		proc, err := os.FindProcess(int(pid))
 		Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
this commit fixes a potential race condition that prevented the tests to succeed when running in a github workflow.
Basically the thread id was not actually available before writing it on the file, resulting in a thread id equals to 0 written in it. So, when the tests were trying to retrieve the thread id to use it to send the WM_QUIT signal, they failed.

This patch adds a check on the thread id before writing it on the file. Now, if the thread id is 0, it keeps calling winquit to retrieve it. If, after 10 secs, there is no success it returns an error.

it resolves #432 