### PR TITLE
Allow empty list of nameservers

### DIFF
--- a/pkg/services/dns/dns_config_unix.go
+++ b/pkg/services/dns/dns_config_unix.go
@@ -3,15 +3,12 @@
 package dns
 
 import (
-	"errors"
 	"net"
 	"net/netip"
 
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 )
-
-var errEmptyResolvConf = errors.New("no DNS servers configured in /etc/resolv.conf")
 
 func getDNSHostAndPort() ([]string, error) {
 	conf, err := dns.ClientConfigFromFile("/etc/resolv.conf")
@@ -31,8 +28,5 @@ func getDNSHostAndPort() ([]string, error) {
 		}
 	}
 
-	if len(hosts) == 0 {
-		return []string{}, errEmptyResolvConf
-	}
 	return hosts, nil
 }

--- a/pkg/services/dns/dns_test.go
+++ b/pkg/services/dns/dns_test.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"context"
-	"errors"
 	"net"
 	"testing"
 	"time"
@@ -24,11 +23,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 	var server *Server
 
 	ginkgo.BeforeEach(func() {
-		var err error
-		server, err = New(nil, nil, []types.Zone{})
-		if errors.Is(err, errEmptyResolvConf) {
-			ginkgo.Skip("Skipping test, no DNS Servers found")
-		}
+		server, _ = New(nil, nil, []types.Zone{})
 	})
 
 	ginkgo.It("should add dns zone with ip", func() {
@@ -235,10 +230,10 @@ type ARecord struct {
 func TestDNS(t *testing.T) {
 	log.Infof("starting test DNS servers")
 	nameserver, cleanup, err := startDNSServer()
-	if errors.Is(err, errEmptyResolvConf) {
+	require.NoError(t, err)
+	if len(nameserver) == 0 {
 		t.Skip("Failed to setup start DNS server, skipping test")
 	}
-	require.NoError(t, err)
 	defer cleanup()
 	time.Sleep(100 * time.Millisecond)
 	log.Infof("test DNS servers started")


### PR DESCRIPTION
gvisor-tap-vsock is used by the Lima project to provide networking support when using the Apple Virtualization framework (VZ).

Up to version gvisor-tap-vsock 0.7.5 this worked fine to start a virtual machine even when the host is offline. In 0.8.0 this fails with a fatal error because `/etc/resolv.conf` is empty (#420), making it impossible to use Lima while offline (https://github.com/lima-vm/lima/issues/3050).

This check and error code seems to have been added to avoid a panic when accessing `nameservers[0]` (#417). At the time #420 was merged, the panicking code seems to already have been replaced. As far as I can tell, the only access is now via `range nameservers`, which automatically does the right thing for an empty slice.

I would like to see #420 reverted (conceptually) so that Lima can work offline again.

PS: The test passes `cd pkg/services/dns && go test ./...`, but I haven't found any documentation on how to run the full set of tests (my naïve attempts showed failures even when running `make test` on the `main` branch, so I guess it needs some additional setup).
