### PR TITLE
Test win-sshproxy with qemu VM

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Test
       run: |
-        sudo -s -u ${USER} bash -c 'make test'
+        sudo -s -u ${USER} bash -c 'make test-linux'
 
     - uses: actions/upload-artifact@v4
       if: always()

--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,7 @@ test-companion:
 .PHONY: test-linux
 test-linux: gvproxy test-companion
 	go test -timeout 20m  -v ./test-qemu
+
+.PHONY: test-mac
+test-mac: gvproxy
+	go test -timeout 20m  -v ./test-vfkit

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,6 @@ cross: $(TOOLS_BINDIR)/makefat
 test-companion:
 	GOOS=linux go build -ldflags "$(LDFLAGS)" -o bin/test-companion ./cmd/test-companion
 
-.PHONY: test
-test: gvproxy test-companion
-	go test -timeout 20m -v ./...
+.PHONY: test-linux
+test-linux: gvproxy test-companion
+	go test -timeout 20m  -v ./test-qemu

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/stretchr/testify v1.10.0
+	github.com/ulikunitz/xz v0.5.12
 	github.com/vishvananda/netlink v1.3.0
 	golang.org/x/crypto v0.29.0
 	golang.org/x/sync v0.9.0
@@ -43,7 +44,7 @@ require (
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
-	golang.org/x/mod v0.20.0 // indirect
+	golang.org/x/mod v0.20.0
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/text v0.20.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 h1:pyC9PaHYZFgEKFdlp3G8RaCKgVpHZnecvArXvPXcFkM=
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701/go.mod h1:P3a5rG4X7tI17Nn3aOIAYr5HbIMukwXG0urG0WuL8OA=
+github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
+github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vishvananda/netlink v1.3.0 h1:X7l42GfcV4S6E4vHTsw48qbrV+9PVojNfIhZcwQdrZk=
 github.com/vishvananda/netlink v1.3.0/go.mod h1:i6NetklAujEcC6fK0JPjT8qSwWyO0HLn4UKG+hGqeJs=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=

--- a/test-qemu/basic_test.go
+++ b/test-qemu/basic_test.go
@@ -1,0 +1,45 @@
+package e2eqemu
+
+import (
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
+	e2e "github.com/containers/gvisor-tap-vsock/test"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("connectivity with qemu", func() {
+	e2e.BasicConnectivityTests(e2e.BasicTestProps{
+		SSHExec: sshExec,
+	})
+})
+
+var _ = ginkgo.Describe("dns with qemu", func() {
+	e2e.BasicDNSTests(e2e.BasicTestProps{
+		SSHExec: sshExec,
+		Sock:    sock,
+	})
+})
+
+var _ = ginkgo.Describe("command-line format", func() {
+	ginkgo.It("should convert Command to command line format", func() {
+		command := types.NewGvproxyCommand()
+		command.AddEndpoint("unix:///tmp/network.sock")
+		command.Debug = true
+		command.AddQemuSocket("tcp://0.0.0.0:1234")
+		command.PidFile = "~/gv-pidfile.txt"
+		command.LogFile = "~/gv.log"
+		command.AddForwardUser("demouser")
+
+		cmd := command.ToCmdline()
+		gomega.Expect(cmd).To(gomega.Equal([]string{
+			"-listen", "unix:///tmp/network.sock",
+			"-debug",
+			"-mtu", "1500",
+			"-ssh-port", "2222",
+			"-listen-qemu", "tcp://0.0.0.0:1234",
+			"-forward-user", "demouser",
+			"-pid-file", "~/gv-pidfile.txt",
+			"-log-file", "~/gv.log",
+		}))
+	})
+})

--- a/test-qemu/efi_darwin_arm64_test.go
+++ b/test-qemu/efi_darwin_arm64_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2eqemu
 
 import (
 	"fmt"

--- a/test-qemu/efi_generic.go
+++ b/test-qemu/efi_generic.go
@@ -1,6 +1,6 @@
 //go:build !(darwin && arm64)
 
-package e2e
+package e2eqemu
 
 func efiArgs() (string, error) {
 	return "", nil

--- a/test-utils/ignition.go
+++ b/test-utils/ignition.go
@@ -1,4 +1,4 @@
-package e2e
+package e2eutils
 
 import (
 	"encoding/json"

--- a/test-utils/ignition_schema.go
+++ b/test-utils/ignition_schema.go
@@ -1,4 +1,4 @@
-package e2e
+package e2eutils
 
 // Taken from https://github.com/coreos/ignition/blob/master/config/v3_2/types/schema.go 
 

--- a/test-utils/port.go
+++ b/test-utils/port.go
@@ -1,0 +1,19 @@
+package e2eutils
+
+import (
+	"fmt"
+	"net"
+)
+
+func IsPortAvailable(port int) bool {
+	return IsHostPortAvailable("127.0.0.1", port)
+}
+
+func IsHostPortAvailable(host string, port int) bool {
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
+	if err != nil {
+		return false
+	}
+	listener.Close()
+	return true
+}

--- a/test-utils/ssh.go
+++ b/test-utils/ssh.go
@@ -1,0 +1,29 @@
+package e2eutils
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func CreateSSHKeys(publicKeyFile, privateKeyFile string) (string, error) {
+	_ = os.Remove(publicKeyFile)
+	_ = os.Remove(privateKeyFile)
+	err := exec.Command("ssh-keygen", "-N", "", "-t", "ed25519", "-f", privateKeyFile).Run()
+	if err != nil {
+		return "", errors.Wrap(err, "Could not generate ssh keys")
+	}
+
+	return readPublicKey(publicKeyFile)
+}
+
+func readPublicKey(publicKeyFile string) (string, error) {
+	publicKey, err := os.ReadFile(publicKeyFile)
+	if err != nil {
+		return "", nil
+	}
+
+	return strings.TrimSpace(string(publicKey)), nil
+}

--- a/test-vfkit/basic_test.go
+++ b/test-vfkit/basic_test.go
@@ -1,0 +1,19 @@
+package e2evfkit
+
+import (
+	e2e "github.com/containers/gvisor-tap-vsock/test"
+	"github.com/onsi/ginkgo"
+)
+
+var _ = ginkgo.Describe("connectivity with vfkit", func() {
+	e2e.BasicConnectivityTests(e2e.BasicTestProps{
+		SSHExec: sshExec,
+	})
+})
+
+var _ = ginkgo.Describe("dns with vfkit", func() {
+	e2e.BasicDNSTests(e2e.BasicTestProps{
+		SSHExec: sshExec,
+		Sock:    sock,
+	})
+})

--- a/test-vfkit/vfkit_suite_test.go
+++ b/test-vfkit/vfkit_suite_test.go
@@ -1,0 +1,219 @@
+package e2evfkit
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	e2e_utils "github.com/containers/gvisor-tap-vsock/test-utils"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
+	"golang.org/x/mod/semver"
+)
+
+func TestSuite(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "gvisor-tap-vsock suite")
+}
+
+const (
+	sock         = "/tmp/gvproxy-api-vfkit.sock"
+	vfkitSock    = "/tmp/vfkit.sock"
+	sshPort      = 2223
+	ignitionUser = "test"
+	// #nosec "test" (for manual usage)
+	ignitionPasswordHash = "$y$j9T$TqJWt3/mKJbH0sYi6B/LD1$QjVRuUgntjTHjAdAkqhkr4F73m.Be4jBXdAaKw98sPC" // notsecret
+	efiStore             = "efi-variable-store"
+	vfkitVersionNeeded   = 0.6
+)
+
+var (
+	tmpDir         string
+	binDir         string
+	host           *exec.Cmd
+	client         *exec.Cmd
+	privateKeyFile string
+	publicKeyFile  string
+	ignFile        string
+)
+
+func init() {
+	flag.StringVar(&tmpDir, "tmpDir", "../tmp", "temporary working directory")
+	flag.StringVar(&binDir, "bin", "../bin", "directory with compiled binaries")
+	privateKeyFile = filepath.Join(tmpDir, "id_test")
+	publicKeyFile = privateKeyFile + ".pub"
+	ignFile = filepath.Join(tmpDir, "test.ign")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	// clear the environment before running the tests. It may happen the tests were abruptly stopped earlier leaving a dirty env
+	clear()
+
+	// check if vfkit version is greater than v0.5 (ignition support is available starting from v0.6)
+	version, err := vfkitVersion()
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	gomega.Expect(version >= vfkitVersionNeeded).Should(gomega.BeTrue())
+
+	// check if ssh port is free
+	gomega.Expect(e2e_utils.IsPortAvailable(sshPort)).Should(gomega.BeTrue())
+
+	gomega.Expect(os.MkdirAll(filepath.Join(tmpDir, "disks"), os.ModePerm)).Should(gomega.Succeed())
+
+	downloader, err := e2e_utils.NewFcosDownloader(filepath.Join(tmpDir, "disks"))
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	fcosImage, err := downloader.DownloadImage("applehv", "raw.gz")
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	publicKey, err := e2e_utils.CreateSSHKeys(publicKeyFile, privateKeyFile)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	err = e2e_utils.CreateIgnition(ignFile, publicKey, ignitionUser, ignitionPasswordHash)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	errors := make(chan error)
+
+outer:
+	for panics := 0; ; panics++ {
+		_ = os.Remove(sock)
+
+		// #nosec
+		host = exec.Command(filepath.Join(binDir, "gvproxy"), fmt.Sprintf("--ssh-port=%d", sshPort), fmt.Sprintf("--listen=unix://%s", sock), fmt.Sprintf("--listen-vfkit=unixgram://%s", vfkitSock))
+
+		host.Stderr = os.Stderr
+		host.Stdout = os.Stdout
+		gomega.Expect(host.Start()).Should(gomega.Succeed())
+		go func() {
+			if err := host.Wait(); err != nil {
+				log.Error(err)
+				errors <- err
+			}
+		}()
+
+		for {
+			_, err := os.Stat(sock)
+			if os.IsNotExist(err) {
+				log.Info("waiting for socket")
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			_, err = os.Stat(vfkitSock)
+			if os.IsNotExist(err) {
+				log.Info("waiting for vfkit socket")
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			break
+		}
+
+		vfkitArgs := `--cpus 2 --memory 2048 --bootloader efi,variable-store=%s,create --device virtio-blk,path=%s --ignition %s  --device virtio-net,unixSocketPath=%s,mac=5a:94:ef:e4:0c:ee`
+		// #nosec
+		client = exec.Command(vfkitExecutable(), strings.Split(fmt.Sprintf(vfkitArgs, efiStore, fcosImage, ignFile, vfkitSock), " ")...)
+		client.Stderr = os.Stderr
+		client.Stdout = os.Stdout
+		gomega.Expect(client.Start()).Should(gomega.Succeed())
+		go func() {
+			if err := client.Wait(); err != nil {
+				log.Error(err)
+				errors <- err
+			}
+		}()
+
+		for {
+			_, err := sshExec("whoami")
+			if err == nil {
+				break outer
+			}
+
+			select {
+			case err := <-errors:
+				log.Errorf("Error %v", err)
+				// this expect will always fail so the tests stop
+				gomega.Expect(err).To(gomega.Equal(nil))
+				break outer
+			case <-time.After(1 * time.Second):
+				log.Infof("waiting for client to connect: %v", err)
+			}
+		}
+	}
+
+	time.Sleep(5 * time.Second)
+})
+
+func vfkitVersion() (float64, error) {
+	executable := vfkitExecutable()
+	if executable == "" {
+		return 0, fmt.Errorf("vfkit executable not found")
+	}
+	out, err := exec.Command(executable, "-v").Output()
+	if err != nil {
+		return 0, err
+	}
+	version := strings.TrimPrefix(string(out), "vfkit version:")
+	majorMinor := strings.TrimPrefix(semver.MajorMinor(strings.TrimSpace(version)), "v")
+	versionF, err := strconv.ParseFloat(majorMinor, 64)
+	if err != nil {
+		return 0, err
+	}
+	return versionF, nil
+}
+
+func vfkitExecutable() string {
+	vfkitBinaries := []string{"vfkit"}
+	for _, binary := range vfkitBinaries {
+		path, err := exec.LookPath(binary)
+		if err == nil && path != "" {
+			return path
+		}
+	}
+
+	return ""
+}
+
+func sshExec(cmd ...string) ([]byte, error) {
+	return sshCommand(cmd...).Output()
+}
+
+func sshCommand(cmd ...string) *exec.Cmd {
+	sshCmd := exec.Command("ssh",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "IdentitiesOnly=yes",
+		"-i", privateKeyFile,
+		"-p", strconv.Itoa(sshPort),
+		fmt.Sprintf("%s@127.0.0.1", ignitionUser), "--", strings.Join(cmd, " ")) // #nosec G204
+	return sshCmd
+}
+
+func clear() {
+	_ = os.Remove(efiStore)
+	_ = os.Remove(sock)
+	_ = os.Remove(vfkitSock)
+
+	// this should be handled by vfkit once https://github.com/crc-org/vfkit/pull/230 gets merged
+	// it removes the ignition.sock file
+	socketPath := filepath.Join(os.TempDir(), "ignition.sock")
+	_ = os.Remove(socketPath)
+}
+
+var _ = ginkgo.AfterSuite(func() {
+	if host != nil {
+		if err := host.Process.Kill(); err != nil {
+			log.Error(err)
+		}
+	}
+	if client != nil {
+		if err := client.Process.Kill(); err != nil {
+			log.Error(err)
+		}
+	}
+	clear()
+})

--- a/test-win-sshproxy/test-qemu/basic_test.go
+++ b/test-win-sshproxy/test-qemu/basic_test.go
@@ -1,0 +1,46 @@
+//go:build windows
+// +build windows
+
+package e2e_win_qemu
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	winio "github.com/Microsoft/go-winio"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var timeout = 1 * time.Minute
+
+var _ = Describe("connectivity", func() {
+	It("proxies over a windows pipe to call podman api", func() {
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return winio.DialPipe(npipePodmanTestPath, &timeout)
+				},
+			},
+		}
+
+		Eventually(func(g Gomega) {
+			resp, err := httpClient.Get("http://localhost/v4.0.2/libpod/info")
+			g.Expect(err).ShouldNot(HaveOccurred())
+			defer resp.Body.Close()
+
+			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			reply := make([]byte, 8)
+			_, err = io.ReadAtLeast(resp.Body, reply, len(reply))
+
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(string(reply)).To(Equal("{\"host\":"))
+
+		}).Should(Succeed())
+	})
+})

--- a/test-win-sshproxy/test-qemu/suite_test.go
+++ b/test-win-sshproxy/test-qemu/suite_test.go
@@ -1,0 +1,187 @@
+//go:build windows
+// +build windows
+
+package e2e_win_qemu
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
+	e2e_utils "github.com/containers/gvisor-tap-vsock/test-utils"
+)
+
+func TestSuite(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "win-sshproxy suite")
+}
+
+const (
+	qemuPort            = 5554
+	ignitionUser        = "test"
+	podmanSock          = "/run/user/1001/podman/podman.sock"
+	podmanRootSock      = "/run/podman/podman.sock"
+	npipePodmanTestPath = "\\\\.\\pipe\\test-win-sshproxy"
+	npipePodmanTest     = "npipe:////./pipe/test-win-sshproxy"
+
+	// #nosec "test" (for manual usage)
+	ignitionPasswordHash = "$y$j9T$TqJWt3/mKJbH0sYi6B/LD1$QjVRuUgntjTHjAdAkqhkr4F73m.Be4jBXdAaKw98sPC"
+)
+
+var (
+	tmpDir          string
+	binDir          string
+	host            *exec.Cmd
+	client          *exec.Cmd
+	privateKeyFile  string
+	publicKeyFile   string
+	ignFile         string
+	forwardSock     string
+	forwardRootSock string
+	qconLog         string
+)
+
+func init() {
+	flag.StringVar(&tmpDir, "tmpDir", "..\\..\\tmp", "temporary working directory")
+	flag.StringVar(&binDir, "bin", "..\\..\\bin", "directory with compiled binaries")
+	privateKeyFile = filepath.Join(tmpDir, "id_test")
+	publicKeyFile = privateKeyFile + ".pub"
+	ignFile = filepath.Join(tmpDir, "test.ign")
+	forwardSock = filepath.Join(tmpDir, "podman-remote.sock")
+	forwardRootSock = filepath.Join(tmpDir, "podman-root-remote.sock")
+	qconLog = filepath.Join(tmpDir, "qcon.log")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	gomega.Expect(os.MkdirAll(filepath.Join(tmpDir, "disks"), os.ModePerm)).Should(gomega.Succeed())
+
+	downloader, err := e2e_utils.NewFcosDownloader(filepath.Join(tmpDir, "disks"))
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	qemuImage, err := downloader.DownloadImage("qemu", "qcow2.xz")
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	publicKey, err := e2e_utils.CreateSSHKeys(publicKeyFile, privateKeyFile)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	err = e2e_utils.CreateIgnition(ignFile, publicKey, ignitionUser, ignitionPasswordHash)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+outer:
+	for panics := 0; ; panics++ {
+		template := `-m 2048 -nographic -serial file:%s -hda %s -fw_cfg name=opt/com.coreos/config,file=%s -nic user,hostfwd=tcp::%d-:22`
+
+		// #nosec
+		client = exec.Command(qemuExecutable(), strings.Split(fmt.Sprintf(template, qconLog, qemuImage, ignFile, qemuPort), " ")...)
+		client.Stderr = os.Stderr
+		client.Stdout = os.Stdout
+		gomega.Expect(client.Start()).Should(gomega.Succeed())
+		go func() {
+			if err := client.Wait(); err != nil {
+				log.Error(err)
+			}
+		}()
+
+		for {
+			_, err := sshExec("whoami")
+			if err == nil {
+				break outer
+			}
+
+			// Check for panic
+			didPanic, err := panicCheck(qconLog)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			if didPanic {
+				gomega.Expect(panics).ToNot(gomega.BeNumerically(">", 15), "No more than 15 panics allowed")
+				log.Info("Detected Kernel panic, retrying...")
+				_ = client.Process.Kill()
+				_ = os.Remove(qconLog)
+				continue outer
+			}
+
+			log.Infof("waiting for client to connect: %v", err)
+			time.Sleep(time.Second)
+		}
+	}
+
+	// #nosec
+	host = exec.Command(filepath.Join(binDir, "win-sshproxy.exe"), "test", tmpDir, npipePodmanTest,
+		fmt.Sprintf("ssh://%s@localhost:%d%s", ignitionUser, qemuPort, podmanSock), privateKeyFile)
+
+	host.Stderr = os.Stderr
+	host.Stdout = os.Stdout
+	gomega.Expect(host.Start()).Should(gomega.Succeed())
+	go func() {
+		if err := host.Wait(); err != nil {
+			log.Error(err)
+		}
+	}()
+
+	time.Sleep(5 * time.Second)
+})
+
+func qemuExecutable() string {
+	binary := fmt.Sprintf("qemu-system-%s.exe", e2e_utils.CoreosArch())
+	path, err := exec.LookPath(binary)
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+func sshExec(cmd ...string) ([]byte, error) {
+	return sshCommand(cmd...).Output()
+}
+
+func sshCommand(cmd ...string) *exec.Cmd {
+	sshCmd := exec.Command("ssh",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "IdentitiesOnly=yes",
+		"-i", privateKeyFile,
+		"-p", strconv.Itoa(qemuPort),
+		fmt.Sprintf("%s@127.0.0.1", ignitionUser), "--", strings.Join(cmd, " ")) // #nosec G204
+	return sshCmd
+}
+
+func panicCheck(con string) (bool, error) {
+	file, err := os.Open(con)
+	if err != nil {
+		return false, err
+	}
+
+	_, _ = file.Seek(-500, io.SeekEnd)
+	// Ignore seek errors (not enough content yet)
+
+	contents := make([]byte, 500)
+	_, err = io.ReadAtLeast(file, contents, len(contents))
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return false, err
+	}
+
+	return strings.Contains(string(contents), "end Kernel panic"), nil
+}
+
+var _ = ginkgo.AfterSuite(func() {
+	if host != nil {
+		if err := host.Process.Kill(); err != nil {
+			log.Error(err)
+		}
+	}
+	if client != nil {
+		if err := client.Process.Kill(); err != nil {
+			log.Error(err)
+		}
+	}
+})

--- a/test/basic_tests.go
+++ b/test/basic_tests.go
@@ -6,14 +6,20 @@ import (
 	"net/http"
 
 	gvproxyclient "github.com/containers/gvisor-tap-vsock/pkg/client"
+
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 )
 
-var _ = ginkgo.Describe("connectivity", func() {
+type BasicTestProps struct {
+	SSHExec func(cmd ...string) ([]byte, error)
+	Sock    string
+}
+
+func BasicConnectivityTests(props BasicTestProps) {
 	ginkgo.It("should configure the interface", func() {
-		out, err := sshExec("ifconfig $(route | grep '^default' | grep -o '[^ ]*$')")
+		out, err := props.SSHExec("ifconfig $(route | grep '^default' | grep -o '[^ ]*$')")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("mtu 1500"))
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("inet 192.168.127.2"))
@@ -22,72 +28,72 @@ var _ = ginkgo.Describe("connectivity", func() {
 	})
 
 	ginkgo.It("should configure the default route", func() {
-		out, err := sshExec("ip route show")
+		out, err := props.SSHExec("ip route show")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.MatchRegexp(`default via 192\.168\.127\.1 dev (.*?) proto dhcp (src 192\.168\.127\.2 )?metric 100`))
 	})
 
 	ginkgo.It("should configure dns settings", func() {
-		out, err := sshExec("cat /etc/resolv.conf")
+		out, err := props.SSHExec("cat /etc/resolv.conf")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("nameserver 192.168.127.1"))
 	})
 
 	ginkgo.It("should ping the tap device", func() {
-		out, err := sshExec("ping -c2 192.168.127.2")
+		out, err := props.SSHExec("ping -c2 192.168.127.2")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("2 packets transmitted, 2 received, 0% packet loss"))
 	})
 
 	ginkgo.It("should ping the gateway", func() {
-		out, err := sshExec("ping -c2 192.168.127.1")
+		out, err := props.SSHExec("ping -c2 192.168.127.1")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("2 packets transmitted, 2 received, 0% packet loss"))
 	})
-})
+}
 
-var _ = ginkgo.Describe("dns", func() {
+func BasicDNSTests(props BasicTestProps) {
 	ginkgo.It("should resolve redhat.com", func() {
-		out, err := sshExec("nslookup redhat.com")
+		out, err := props.SSHExec("nslookup redhat.com")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("Address: 52.200.142.250"))
 	})
 
 	ginkgo.It("should resolve CNAME record for docs.crc.dev", func() {
-		out, err := sshExec("nslookup -query=cname docs.crc.dev")
+		out, err := props.SSHExec("nslookup -query=cname docs.crc.dev")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("docs.crc.dev	canonical name = webredir.gandi.net."))
 	})
 	ginkgo.It("should resolve MX record for crc.dev", func() {
-		out, err := sshExec("nslookup -query=mx crc.dev")
+		out, err := props.SSHExec("nslookup -query=mx crc.dev")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("crc.dev	mail exchanger = 10 spool.mail.gandi.net."))
 	})
 
 	ginkgo.It("should resolve NS record for wikipedia.org", func() {
-		out, err := sshExec("nslookup -query=ns wikipedia.org")
+		out, err := props.SSHExec("nslookup -query=ns wikipedia.org")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("wikipedia.org	nameserver = ns0.wikimedia.org."))
 	})
 	ginkgo.It("should resolve IMAPS SRV record for crc.dev", func() {
-		out, err := sshExec("nslookup -query=srv _imaps._tcp.crc.dev")
+		out, err := props.SSHExec("nslookup -query=srv _imaps._tcp.crc.dev")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring(`_imaps._tcp.crc.dev	service = 0 1 993 mail.gandi.net.`))
 	})
 	ginkgo.It("should resolve TXT for crc.dev", func() {
-		out, err := sshExec("nslookup -query=txt crc.dev")
+		out, err := props.SSHExec("nslookup -query=txt crc.dev")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring(`text = "v=spf1`))
 	})
 
 	ginkgo.It("should resolve gateway.containers.internal", func() {
-		out, err := sshExec("nslookup gateway.containers.internal")
+		out, err := props.SSHExec("nslookup gateway.containers.internal")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("Address: 192.168.127.1"))
 	})
 
 	ginkgo.It("should resolve host.containers.internal", func() {
-		out, err := sshExec("nslookup host.containers.internal")
+		out, err := props.SSHExec("nslookup host.containers.internal")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("Address: 192.168.127.254"))
 	})
@@ -96,7 +102,7 @@ var _ = ginkgo.Describe("dns", func() {
 		client := gvproxyclient.New(&http.Client{
 			Transport: &http.Transport{
 				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial("unix", sock)
+					return net.Dial("unix", props.Sock)
 				},
 			},
 		}, "http://base")
@@ -111,7 +117,7 @@ var _ = ginkgo.Describe("dns", func() {
 		})
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-		out, err := sshExec("nslookup test.dynamic.internal")
+		out, err := props.SSHExec("nslookup test.dynamic.internal")
 
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("Address: 192.168.127.254"))
@@ -121,7 +127,7 @@ var _ = ginkgo.Describe("dns", func() {
 		client := gvproxyclient.New(&http.Client{
 			Transport: &http.Transport{
 				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial("unix", sock)
+					return net.Dial("unix", props.Sock)
 				},
 			},
 		}, "http://base")
@@ -147,7 +153,7 @@ var _ = ginkgo.Describe("dns", func() {
 		})
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-		out, err := sshExec("nslookup test.dynamic.internal")
+		out, err := props.SSHExec("nslookup test.dynamic.internal")
 
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("Address: 192.168.127.253"))
@@ -157,7 +163,7 @@ var _ = ginkgo.Describe("dns", func() {
 		client := gvproxyclient.New(&http.Client{
 			Transport: &http.Transport{
 				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial("unix", sock)
+					return net.Dial("unix", props.Sock)
 				},
 			},
 		}, "http://base")
@@ -174,7 +180,7 @@ var _ = ginkgo.Describe("dns", func() {
 				},
 			},
 		})
-		out, err := sshExec("nslookup test.dynamic.internal")
+		out, err := props.SSHExec("nslookup test.dynamic.internal")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("Address: 192.168.127.2"))
 
@@ -187,36 +193,12 @@ var _ = ginkgo.Describe("dns", func() {
 				},
 			},
 		})
-		out, err = sshExec("nslookup *.dynamic.testing")
+		out, err = props.SSHExec("nslookup *.dynamic.testing")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("Address: 192.168.127.2"))
 
-		out, err = sshExec("nslookup gateway.testing")
+		out, err = props.SSHExec("nslookup gateway.testing")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(string(out)).To(gomega.ContainSubstring("Address: 192.168.127.1"))
 	})
-})
-
-var _ = ginkgo.Describe("command-line format", func() {
-	ginkgo.It("should convert Command to command line format", func() {
-		command := types.NewGvproxyCommand()
-		command.AddEndpoint("unix:///tmp/network.sock")
-		command.Debug = true
-		command.AddQemuSocket("tcp://0.0.0.0:1234")
-		command.PidFile = "~/gv-pidfile.txt"
-		command.LogFile = "~/gv.log"
-		command.AddForwardUser("demouser")
-
-		cmd := command.ToCmdline()
-		gomega.Expect(cmd).To(gomega.Equal([]string{
-			"-listen", "unix:///tmp/network.sock",
-			"-debug",
-			"-mtu", "1500",
-			"-ssh-port", "2222",
-			"-listen-qemu", "tcp://0.0.0.0:1234",
-			"-forward-user", "demouser",
-			"-pid-file", "~/gv-pidfile.txt",
-			"-log-file", "~/gv.log",
-		}))
-	})
-})
+}


### PR DESCRIPTION
it adds the logic to test win-sshproxy by using a qemu VM with fcos and see if the ssh tunneling between host/guest on the podman socket works as expected.

The qemu VM can also be reused for further extensive testing