### PR TITLE
Sync DNS Resolver Nameserver List

### DIFF
--- a/pkg/services/dns/dns_config.go
+++ b/pkg/services/dns/dns_config.go
@@ -1,0 +1,24 @@
+package dns
+
+import "sync"
+
+type dnsConfig struct {
+	mu          sync.RWMutex
+	nameservers []string
+}
+
+func newDNSConfig() (*dnsConfig, error) {
+	r := &dnsConfig{nameservers: []string{}}
+	if err := r.init(); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (r *dnsConfig) Nameservers() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.nameservers
+}

--- a/pkg/services/dns/dns_config_unix.go
+++ b/pkg/services/dns/dns_config_unix.go
@@ -6,16 +6,51 @@ import (
 	"net"
 	"net/netip"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/utils"
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 )
 
-func getDNSHostAndPort() ([]string, error) {
-	conf, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+func (r *dnsConfig) init() error {
+	if err := r.refreshNameservers(); err != nil {
+		return err
+	}
+
+	w, err := utils.NewFileWatcher(etcResolvConfPath)
+	if err != nil {
+		return err
+	}
+
+	if err := w.Start(func() { _ = r.refreshNameservers() }); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *dnsConfig) refreshNameservers() error {
+	nsList, err := getDNSHostAndPort(etcResolvConfPath)
+	if err != nil {
+		log.Errorf("can't load dns nameservers: %v", err)
+		return err
+	}
+
+	log.Infof("reloading dns nameservers to %v", nsList)
+
+	r.mu.Lock()
+	r.nameservers = nsList
+	r.mu.Unlock()
+	return nil
+}
+
+const etcResolvConfPath = "/etc/resolv.conf"
+
+func getDNSHostAndPort(path string) ([]string, error) {
+	conf, err := dns.ClientConfigFromFile(path)
 	if err != nil {
 		return []string{}, err
 	}
-	var hosts = make([]string, len(conf.Servers))
+	hosts := make([]string, 0, len(conf.Servers))
 	for _, server := range conf.Servers {
 		dnsIP, err := netip.ParseAddr(server)
 		if err != nil {

--- a/pkg/services/dns/dns_config_windows.go
+++ b/pkg/services/dns/dns_config_windows.go
@@ -9,6 +9,16 @@ import (
 	qdmDns "github.com/qdm12/dns/v2/pkg/nameserver"
 )
 
+func (r *dnsConfig) init() error {
+	nsList, err := getDNSHostAndPort()
+	if err != nil {
+		return err
+	}
+
+	r.nameservers = nsList
+	return nil
+}
+
 func getDNSHostAndPort() ([]string, error) {
 	nameservers := qdmDns.GetDNSServers()
 
@@ -21,5 +31,4 @@ func getDNSHostAndPort() ([]string, error) {
 	}
 
 	return dnsServers, nil
-
 }

--- a/pkg/utils/filewatcher.go
+++ b/pkg/utils/filewatcher.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// FileWatcher is an utility that
+type FileWatcher struct {
+	w    *fsnotify.Watcher
+	path string
+
+	writeGracePeriod time.Duration
+	timer            *time.Timer
+}
+
+func NewFileWatcher(path string) (*FileWatcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	return &FileWatcher{w: watcher, path: path, writeGracePeriod: 200 * time.Millisecond}, nil
+}
+
+func (fw *FileWatcher) Start(changeHandler func()) error {
+	// Ensure that the target that we're watching is not a symlink as we won't get any events when we're watching
+	// a symlink.
+	fileRealPath, err := filepath.EvalSymlinks(fw.path)
+	if err != nil {
+		return fmt.Errorf("adding watcher failed: %s", err)
+	}
+
+	// watch the directory instead of the individual file to ensure the notification still works when the file is modified
+	// through moving/renaming rather than writing into it directly (like what most modern editor does by default).
+	// ref: https://github.com/fsnotify/fsnotify/blob/a9bc2e01792f868516acf80817f7d7d7b3315409/README.md#watching-a-file-doesnt-work-well
+	if err = fw.w.Add(filepath.Dir(fileRealPath)); err != nil {
+		return fmt.Errorf("adding watcher failed: %s", err)
+	}
+
+	go func() {
+		for {
+			select {
+			case _, ok := <-fw.w.Errors:
+				if !ok {
+					return // watcher is closed.
+				}
+			case event, ok := <-fw.w.Events:
+				if !ok {
+					return // watcher is closed.
+				}
+
+				if event.Name != fileRealPath {
+					continue // we don't care about this file.
+				}
+
+				// Create may not always followed by Write e.g. when we replace the file with mv.
+				if event.Op.Has(fsnotify.Create) || event.Op.Has(fsnotify.Write) {
+					// as per the documentation, receiving Write does not mean that the write is finished.
+					// we try our best here to ignore "unfinished" write by assuming that after [writeGracePeriod] of
+					// inactivity the write has been finished.
+					fw.debounce(changeHandler)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (fw *FileWatcher) debounce(fn func()) {
+	if fw.timer != nil {
+		fw.timer.Stop()
+	}
+
+	fw.timer = time.AfterFunc(fw.writeGracePeriod, fn)
+}
+
+func (fw *FileWatcher) Stop() error {
+	return fw.w.Close()
+}

--- a/pkg/utils/filewatcher_test.go
+++ b/pkg/utils/filewatcher_test.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileWatcher(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	_ = os.WriteFile(path, []byte("1"), 0o600)
+
+	fw, err := NewFileWatcher(path)
+	fw.writeGracePeriod = 50 * time.Millisecond // reduce the delay to make the test runs faster.
+	assert.NoError(t, err)
+	_ = fw.w.Add(path)
+
+	var numTriggered atomic.Int64
+	assertNumTriggered := func(expected int) {
+		time.Sleep(fw.writeGracePeriod + 50*time.Millisecond)
+		assert.Equal(t, int64(expected), numTriggered.Load())
+	}
+
+	_ = fw.Start(func() {
+		numTriggered.Add(1)
+	})
+
+	// CASE: can detect changes to the file.
+	if err := os.WriteFile(path, []byte("2"), 0o600); err != nil {
+		panic(err)
+	}
+	assertNumTriggered(1)
+
+	// CASE: can detect "swap"-based file modification.
+	tmpFile := filepath.Join(dir, "tmp.txt")
+	if err := os.WriteFile(tmpFile, []byte("lol"), 0o600); err != nil {
+		panic(err)
+	}
+	if err := os.Rename(tmpFile, path); err != nil {
+		panic(err)
+	}
+	assertNumTriggered(2)
+
+	// CASE: combine multiple partial writes into single event.
+	fd, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		panic(err)
+	}
+	// we assume these writes happens in less than 50ms.
+	_, _ = fd.Write([]byte("a"))
+	_ = fd.Sync()
+	_, _ = fd.Write([]byte("b"))
+	fd.Close()
+	assertNumTriggered(3)
+
+	// CASE: closed file watcher should not call the callback after Stop() is called.
+	assert.NoError(t, fw.Stop())
+	if err := os.WriteFile(path, []byte("2"), 0o600); err != nil {
+		panic(err)
+	}
+	assertNumTriggered(3) // does not change.
+}


### PR DESCRIPTION
gvisor-tap-vsock only reads the `/etc/resolv.conf` during init time and does not subscribe into the changes that is made on that file. That is fine, but if i start gvisor-tap-vsock before I connected to my work VPN (which modifies /etc/resolv.conf) after I connected to the VPN i will no longer be able to resolve any DNS queries made from my VM because the original IP that gvisor-tap-vsock is using is no longer reachable once I connected to my work VPN.

gvisor-tap-vsock log:
```
time="2025-01-07T16:57:43+08:00" level=error msg="Error during DNS Exchange: read udp <my-ip>:52316->192.168.50.1:53: i/o timeout"
```

In this PR, I added functionality to ensure that the nameservers that we use to resolve DNS queries are up-to-date with the content of the `/etc/resolv.conf`