### PR TITLE
Revert "Update ubuntu runner to 'ubuntu-24.04'"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04 # explicitly use 20.04, see commit 428c40018f
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04 # explicitly use 20.04, see commit 428c40018a
+    runs-on: ubuntu-20.04 # explicitly use 20.04, see commit 428c40018f
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
This reverts commit 29595055c8fad35e7ac750d6ddeb78c83c7ec1f9. We prefer to stick with older ubuntu releases for building because of https://github.com/containers/gvisor-tap-vsock/issues/256 The issue with qemu with ubuntu 20.04 was fixed with https://github.com/containers/gvisor-tap-vsock/commit/fe7285a8a6a

Ubuntu 20.04 will be EOL'ed in April and the runner images will also go away so we'll need to revisit this:
https://github.com/actions/runner-images/issues/11101

Some options are to switch to Ubuntu 22.04 for our builds, or to look into having pure go builds or statically linked builds, ...