### PR TITLE
Run unit tests on linux

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Test
       run: |
-        sudo -s -u ${USER} bash -c 'make test-linux'
+        sudo -s -u ${USER} bash -c 'make test'
 
     - uses: actions/upload-artifact@v4
       if: always()

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,12 @@ cross: $(TOOLS_BINDIR)/makefat
 test-companion:
 	GOOS=linux go build -ldflags "$(LDFLAGS)" -o bin/test-companion ./cmd/test-companion
 
-.PHONY: test-linux
-test-linux: gvproxy test-companion
+PHONY: test
+test: gvproxy test-companion
+	go test -timeout 20m -v ./...
+
+.PHONY: test-qemu
+test-qemu: gvproxy test-companion
 	go test -timeout 20m  -v ./test-qemu
 
 .PHONY: test-mac

--- a/test-vfkit/basic_test.go
+++ b/test-vfkit/basic_test.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package e2evfkit
 
 import (

--- a/test-vfkit/vfkit_suite_test.go
+++ b/test-vfkit/vfkit_suite_test.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package e2evfkit
 
 import (


### PR DESCRIPTION
https://github.com/containers/gvisor-tap-vsock/commit/b525dc8c691c81a94e5c3ca7953761dea97aa900#r1909010646 updated the gh workflow to run tests. However, it causes some tests to not being run anymore.
This patch re-add back the `test `command and filters the vfkit tests using the go build tag