### PR TITLE
gvproxy: Add --pcap option

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-20.04 # explicitly use 20.04, see commit 428c40018f
+    runs-on: ubuntu-22.04 # explicitly use older ubuntu, see commit 428c40018f
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.22.x", "1.23.x"]
+        go-version: ["1.23.x", "1.24.x"]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -32,7 +32,7 @@ jobs:
         mv bin/gvproxy.exe bin/gvproxy-windowsgui.exe
 
     - uses: actions/upload-artifact@v4
-      if: matrix.go-version == '1.22.x'
+      if: matrix.go-version == '1.23.x'
       with:
         name: gvisor-tap-vsock-binaries
         path: bin/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04 # explicitly use 20.04, see commit 428c40018f
+    runs-on: ubuntu-22.04 # explicitly use older ubuntu, see commit 428c40018f
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -44,6 +44,7 @@ var (
 	forwardIdentify  arrayFlags
 	sshPort          int
 	pidFile          string
+	pcapFile         string
 	exitCode         int
 	logFile          string
 	servicesEndpoint string
@@ -62,6 +63,7 @@ func main() {
 	version.AddFlag()
 	flag.Var(&endpoints, "listen", "control endpoint")
 	flag.BoolVar(&debug, "debug", false, "Print debug info")
+	flag.StringVar(&pcapFile, "pcap", "", "Capture network traffic to a pcap file")
 	flag.IntVar(&mtu, "mtu", 1500, "Set the MTU")
 	flag.IntVar(&sshPort, "ssh-port", 2222, "Port to access the guest virtual machine. Must be between 1024 and 65535")
 	flag.StringVar(&vpnkitSocket, "listen-vpnkit", "", "VPNKit socket to be used by Hyperkit")
@@ -215,7 +217,7 @@ func main() {
 
 	config := types.Configuration{
 		Debug:             debug,
-		CaptureFile:       captureFile(),
+		CaptureFile:       pcapFile,
 		MTU:               mtu,
 		Subnet:            "192.168.127.0/24",
 		GatewayIP:         gatewayIP,
@@ -303,13 +305,6 @@ func (i *arrayFlags) String() string {
 func (i *arrayFlags) Set(value string) error {
 	*i = append(*i, value)
 	return nil
-}
-
-func captureFile() string {
-	if !debug {
-		return ""
-	}
-	return "capture.pcap"
 }
 
 func run(ctx context.Context, g *errgroup.Group, configuration *types.Configuration, endpoints []string, servicesEndpoint string) error {


### PR DESCRIPTION
Instead of always writing to a `capture.pcap` file in the current
directory when --debug is used, this commit introduces a separate --pcap
argument, which can also be used to specify the path to the capture
file.
These pcap files can get huge, and are not always useful when debug logs
are requested, so it’s better to separate --debug and --pcap.