### PR TITLE
packit: Switch back to fedora-all alias

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,10 +25,8 @@ jobs:
     packages: [gvisor-tap-vsock-fedora]
     enable_net: true
     targets:
-      - fedora-development-x86_64
-      - fedora-development-aarch64
-      - fedora-latest-stable-x86_64
-      - fedora-latest-stable-aarch64
+      - fedora-all-aarch64
+      - fedora-all-x86_64
       - fedora-eln-aarch64
       - fedora-eln-x86_64
 
@@ -56,8 +54,7 @@ jobs:
     packages: [gvisor-tap-vsock-fedora]
     update_release: false
     dist_git_branches:
-      - fedora-development
-      - fedora-latest-stable
+      - fedora-all
 
   - job: propose_downstream
     trigger: release
@@ -70,12 +67,10 @@ jobs:
     trigger: commit
     packages: [gvisor-tap-vsock-fedora]
     dist_git_branches:
-      - fedora-development
-      - fedora-latest-stable
+      - fedora-all
 
   - job: bodhi_update
     trigger: commit
     packages: [gvisor-tap-vsock-fedora]
     dist_git_branches:
-      - fedora-latest # rawhide updates are created automatically
-      - fedora-latest-stable
+      - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
All supported/development fedora releases have a new enough golang
version, so we can start using the `fedora-all` alias again.
Without it, we are missing f41 builds.