### PR TITLE
Don't show an ERROR when ignoring a RELEASE message

### DIFF
--- a/pkg/services/dhcp/dhcp.go
+++ b/pkg/services/dhcp/dhcp.go
@@ -67,6 +67,9 @@ func handler(configuration *types.Configuration, ipPool *tap.IPPool) server4.Han
 			reply.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeOffer))
 		case dhcpv4.MessageTypeRequest:
 			reply.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeAck))
+		case dhcpv4.MessageTypeRelease:
+			log.Debugf("dhcp: unhandled message type: %v", mt)
+			return
 		default:
 			log.Errorf("dhcp: unhandled message type: %v", mt)
 			return


### PR DESCRIPTION
The RELEASE message is optional anyways, so not handling it is not a critical error that a user needs to worry about.

Lima users are getting confused about the error message when they shut down a VM: https://github.com/lima-vm/lima/discussions/3776