### PR TITLE
Rename SSH keys files

### DIFF
--- a/test-qemu/suite_test.go
+++ b/test-qemu/suite_test.go
@@ -53,7 +53,7 @@ var (
 func init() {
 	flag.StringVar(&tmpDir, "tmpDir", "../tmp", "temporary working directory")
 	flag.StringVar(&binDir, "bin", "../bin", "directory with compiled binaries")
-	privateKeyFile = filepath.Join(tmpDir, "id_test")
+	privateKeyFile = filepath.Join(tmpDir, "id_test_qemu")
 	publicKeyFile = privateKeyFile + ".pub"
 	ignFile = filepath.Join(tmpDir, "test.ign")
 	forwardSock = filepath.Join(tmpDir, "podman-remote.sock")

--- a/test-vfkit/vfkit_suite_test.go
+++ b/test-vfkit/vfkit_suite_test.go
@@ -54,7 +54,7 @@ var debugEnabled = flag.Bool("debug", false, "enable debugger")
 func init() {
 	flag.StringVar(&tmpDir, "tmpDir", "../tmp", "temporary working directory")
 	flag.StringVar(&binDir, "bin", "../bin", "directory with compiled binaries")
-	privateKeyFile = filepath.Join(tmpDir, "id_test")
+	privateKeyFile = filepath.Join(tmpDir, "id_test_vfkit")
 	publicKeyFile = privateKeyFile + ".pub"
 	ignFile = filepath.Join(tmpDir, "test.ign")
 	cmdDir = "../cmd"


### PR DESCRIPTION
We use same ssh keys file name for both test suits(qemu and vfkit) and it is sometime(often) me lead to failing test locally.