### PR TITLE
feat: add DNS whitelist filtering via nil IP forwarding

### DIFF
--- a/pkg/services/dns/dns.go
+++ b/pkg/services/dns/dns.go
@@ -66,6 +66,12 @@ func (h *dnsHandler) addLocalAnswers(m *dns.Msg, q dns.Question) bool {
 				withoutZone := strings.TrimSuffix(q.Name, zoneSuffix)
 				if (record.Name != "" && record.Name == withoutZone) ||
 					(record.Regexp != nil && record.Regexp.MatchString(withoutZone)) {
+					// Allow forwarding to upstream when IP is nil/empty
+					// This enables whitelist filtering: domains with nil IP forward upstream,
+					// while unlisted domains are blocked by defaultIP
+					if record.IP == nil || record.IP.Equal(net.IP{}) {
+						return false // Forward to upstream DNS
+					}
 					m.Answer = append(m.Answer, &dns.A{
 						Hdr: dns.RR_Header{
 							Name:   q.Name,


### PR DESCRIPTION
## Summary

Allow DNS records with nil/empty IP to forward queries to upstream DNS instead of returning a local answer. This enables **whitelist-based DNS filtering** for sandboxed environments.

## Problem

When running untrusted code in sandboxed VMs, you often need to:
- Allow access to specific domains (e.g., package registries like `pypi.org`)
- Block all other domains by default

Previously, DNS zones could only return fixed IPs. There was no way to selectively forward certain domains to upstream DNS while blocking others.

## Solution

Records with `nil` or empty IP now forward to upstream DNS instead of returning a local response. Combined with `defaultIP`, this creates a whitelist pattern:

```yaml
zones:
  - name: "."
    defaultIP: "0.0.0.0"  # Block all domains by default (NXDOMAIN)
    records:
      # Whitelist: these domains forward to upstream DNS
      - regexp: "^(.*\\.)?pypi\\.org\\.?$"
        # No IP = forward to upstream
      - regexp: "^(.*\\.)?files\\.pythonhosted\\.org\\.?$"
        # No IP = forward to upstream
```

## Use Cases

1. **Sandboxed code execution** - Allow package installation from registries while blocking exfiltration to arbitrary domains
2. **CI/CD pipelines** - Restrict network access to approved artifact repositories
3. **Development environments** - Test with limited network access

## Behavior Matrix

| Domain | Record Exists | Record IP | Result |
|--------|--------------|-----------|--------|
| `pypi.org` | ✅ | nil | Forward to upstream DNS |
| `evil.com` | ❌ | - | Return `defaultIP` (blocked) |
| `internal.local` | ✅ | `192.168.1.1` | Return `192.168.1.1` |

## Test Plan

- [x] Verify DNS queries for domains with nil IP are forwarded upstream
- [x] Verify domains with explicit IP still return that IP  
- [x] Verify unlisted domains get `defaultIP` response
- [x] Verify regex patterns match correctly (with/without subdomain, with/without trailing dot)

🤖 Generated with [Claude Code](https://claude.ai/code)