### PR TITLE
feat: add blockAllOutbound option to block guest-initiated connections

### DIFF
--- a/pkg/services/forwarder/udp.go
+++ b/pkg/services/forwarder/udp.go
@@ -14,9 +14,15 @@ import (
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
-func UDP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mutex) *udp.Forwarder {
+func UDP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mutex, blockAllOutbound bool) *udp.Forwarder {
 	return udp.NewForwarder(s, func(r *udp.ForwarderRequest) {
 		localAddress := r.ID().LocalAddress
+
+		if blockAllOutbound {
+			log.Debugf("Blocking outbound UDP to %s:%d (blockAllOutbound=true)",
+				localAddress.String(), r.ID().LocalPort)
+			return
+		}
 
 		if linkLocal().Contains(localAddress) || localAddress == header.IPv4Broadcast {
 			return

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -53,6 +53,9 @@ type Configuration struct {
 
 	// EC2 Metadata Service Access
 	Ec2MetadataAccess bool `yaml:"ec2MetadataAccess,omitempty"`
+
+	// Block all guest-initiated outbound TCP/UDP connections (host→guest forwarding still works)
+	BlockAllOutbound bool `yaml:"blockAllOutbound,omitempty"`
 }
 
 type Protocol string

--- a/pkg/virtualnetwork/services.go
+++ b/pkg/virtualnetwork/services.go
@@ -24,9 +24,9 @@ func addServices(configuration *types.Configuration, s *stack.Stack, ipPool *tap
 	var natLock sync.Mutex
 	translation := parseNATTable(configuration)
 
-	tcpForwarder := forwarder.TCP(s, translation, &natLock, configuration.Ec2MetadataAccess)
+	tcpForwarder := forwarder.TCP(s, translation, &natLock, configuration.Ec2MetadataAccess, configuration.BlockAllOutbound)
 	s.SetTransportProtocolHandler(tcp.ProtocolNumber, tcpForwarder.HandlePacket)
-	udpForwarder := forwarder.UDP(s, translation, &natLock)
+	udpForwarder := forwarder.UDP(s, translation, &natLock, configuration.BlockAllOutbound)
 	s.SetTransportProtocolHandler(udp.ProtocolNumber, udpForwarder.HandlePacket)
 
 	dnsMux, err := dnsServer(configuration, s)


### PR DESCRIPTION
## Summary

Add new configuration option `blockAllOutbound` that blocks all guest-initiated outbound TCP/UDP connections at the network layer, while preserving host-to-guest port forwarding.

## Problem

DNS whitelist filtering (#599) blocks domain resolution for unauthorized domains, but **guests can still connect to hardcoded IP addresses** (e.g., `curl http://93.184.216.34`). This is a security gap for sandboxed environments that require true network isolation.

## Solution

When `blockAllOutbound: true`, the TCP and UDP forwarders reject all guest-initiated outbound connections before they reach `net.Dial()`. This provides defense-in-depth alongside DNS filtering.

```yaml
blockAllOutbound: true
forwards:
  "127.0.0.1:8080": "192.168.127.2:8080"  # Host→Guest still works
```

## Use Cases

1. **Sandboxed code execution** - Run untrusted code with port forwarding for health checks, but no ability to exfiltrate data via direct IP connections
2. **Isolated testing environments** - Expose services for testing while preventing outbound traffic
3. **Air-gapped workloads** - Complete network isolation except for explicit port forwards

## What Still Works vs What's Blocked

| Feature | `blockAllOutbound: false` | `blockAllOutbound: true` |
|---------|--------------------------|-------------------------|
| Guest → Internet (TCP) | ✅ Allowed | ❌ Blocked |
| Guest → Internet (UDP) | ✅ Allowed | ❌ Blocked |
| Guest → Direct IP | ✅ Allowed | ❌ Blocked |
| Host → Guest (Forwards) | ✅ Works | ✅ Works |
| DHCP (IP assignment) | ✅ Works | ✅ Works |
| DNS (via zones) | ✅ Works | ✅ Works |

## Combined with DNS Filtering (#599)

For maximum isolation, combine both features:

```yaml
blockAllOutbound: true          # Block all outbound TCP/UDP
zones:
  - name: "."
    defaultIP: "0.0.0.0"        # Block DNS for unlisted domains
    records:
      - regexp: "^(.*\\.)?allowed\\.example\\.com\\.?$"
        # Whitelist (forwards to upstream)
forwards:
  "127.0.0.1:8080": "192.168.127.2:8080"  # Only way to reach guest
```

This ensures:
- Guest cannot resolve unauthorized domains (DNS blocked)
- Guest cannot connect to any IP directly (TCP/UDP blocked)
- Host can still reach guest via explicit port forwards

## Implementation

- `pkg/types/configuration.go` - Add `BlockAllOutbound bool` field
- `pkg/services/forwarder/tcp.go` - Early return when flag is true
- `pkg/services/forwarder/udp.go` - Early return when flag is true
- `pkg/virtualnetwork/services.go` - Pass flag to forwarders

## Test Plan

- [x] Verify guest cannot initiate outbound TCP connections
- [x] Verify guest cannot initiate outbound UDP connections
- [x] Verify host→guest port forwarding still works via `Forwards` config
- [x] Verify DHCP still works (guest gets IP)
- [x] Verify DNS still works (filtered by zones)

🤖 Generated with [Claude Code](https://claude.ai/code)