### PR TITLE
Add DNS cache to deduplicate upstream lookups

### DIFF
--- a/pkg/dnscache/cache.go
+++ b/pkg/dnscache/cache.go
@@ -1,0 +1,122 @@
+package dnscache
+
+import (
+	"container/list"
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultMaxEntries is a generous default for sandboxed environments
+	// that typically query tens of domains.
+	DefaultMaxEntries = 10000
+
+	// DefaultTTL is the expiry for cached entries. Kept short to avoid
+	// serving stale results to clients without their own cache.
+	DefaultTTL = 5 * time.Second
+)
+
+type entry struct {
+	domain    string // key stored in entry for O(1) eviction (list element -> map delete)
+	ips       []net.IPAddr
+	expiresAt time.Time
+}
+
+// DNSCache is a thread-safe LRU cache mapping domain names to resolved IP
+// addresses. Each entry has a TTL after which it is lazily evicted on access.
+// When the cache is full, the least recently used entry is evicted.
+type DNSCache struct {
+	mu         sync.Mutex
+	items      map[string]*list.Element // domain -> list element
+	order      *list.List               // front = most recently used, back = LRU
+	maxEntries int
+	ttl        time.Duration
+}
+
+// New creates a DNSCache with the given capacity and TTL.
+// It panics if maxEntries <= 0 or ttl <= 0.
+func New(maxEntries int, ttl time.Duration) *DNSCache {
+	if maxEntries <= 0 {
+		panic("dnscache: maxEntries must be > 0")
+	}
+	if ttl <= 0 {
+		panic("dnscache: ttl must be > 0")
+	}
+	return &DNSCache{
+		items:      make(map[string]*list.Element),
+		order:      list.New(),
+		maxEntries: maxEntries,
+		ttl:        ttl,
+	}
+}
+
+// Put stores the domain-to-IPs mapping. If the domain already exists, its IPs
+// and expiry are updated and it is promoted to the front (most recently used).
+// If the cache is at capacity, the least recently used entry is evicted.
+func (c *DNSCache) Put(domain string, ips []net.IPAddr) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if el, ok := c.items[domain]; ok {
+		// Update existing entry and move to front.
+		e := el.Value.(*entry)
+		e.ips = ips
+		e.expiresAt = time.Now().Add(c.ttl)
+		c.order.MoveToFront(el)
+		return
+	}
+
+	// Evict LRU if at capacity.
+	if len(c.items) >= c.maxEntries {
+		c.evictLRU()
+	}
+
+	el := c.order.PushFront(&entry{
+		domain:    domain,
+		ips:       ips,
+		expiresAt: time.Now().Add(c.ttl),
+	})
+	c.items[domain] = el
+}
+
+// Get returns the cached IPs for the domain. On a hit that has not expired the
+// entry is promoted to the front. Expired entries are lazily deleted.
+// Returns (nil, false) on miss or expiry.
+func (c *DNSCache) Get(domain string) ([]net.IPAddr, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	el, ok := c.items[domain]
+	if !ok {
+		return nil, false
+	}
+
+	e := el.Value.(*entry)
+	if time.Now().After(e.expiresAt) {
+		// Lazy cleanup of expired entry.
+		c.order.Remove(el)
+		delete(c.items, domain)
+		return nil, false
+	}
+
+	c.order.MoveToFront(el)
+	return e.ips, true
+}
+
+// Len returns the current number of entries in the cache.
+func (c *DNSCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.items)
+}
+
+// evictLRU removes the least recently used entry. Must be called with mu held.
+func (c *DNSCache) evictLRU() {
+	el := c.order.Back()
+	if el == nil {
+		return
+	}
+	c.order.Remove(el)
+	delete(c.items, el.Value.(*entry).domain)
+}

--- a/pkg/dnscache/cache_test.go
+++ b/pkg/dnscache/cache_test.go
@@ -1,0 +1,426 @@
+package dnscache
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func ip(s string) net.IPAddr { return net.IPAddr{IP: net.ParseIP(s)} }
+
+// --- Normal cases ---
+
+func TestPutAndGet(t *testing.T) {
+	c := New(100, time.Minute)
+	ips := []net.IPAddr{ip("1.2.3.4")}
+	c.Put("example.com", ips)
+
+	got, ok := c.Get("example.com")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if len(got) != 1 || !got[0].IP.Equal(ips[0].IP) {
+		t.Fatalf("got %v, want %v", got, ips)
+	}
+}
+
+func TestGetMiss(t *testing.T) {
+	c := New(100, time.Minute)
+	got, ok := c.Get("no.such.domain")
+	if ok || got != nil {
+		t.Fatalf("expected miss, got %v %v", got, ok)
+	}
+}
+
+func TestPutOverwrite(t *testing.T) {
+	c := New(100, time.Minute)
+	c.Put("example.com", []net.IPAddr{ip("1.1.1.1")})
+	c.Put("example.com", []net.IPAddr{ip("2.2.2.2")})
+
+	got, ok := c.Get("example.com")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if len(got) != 1 || !got[0].IP.Equal(net.ParseIP("2.2.2.2")) {
+		t.Fatalf("got %v, want 2.2.2.2", got)
+	}
+	if c.Len() != 1 {
+		t.Fatalf("expected len 1, got %d", c.Len())
+	}
+}
+
+func TestMultipleKeys(t *testing.T) {
+	c := New(100, time.Minute)
+	c.Put("a.com", []net.IPAddr{ip("1.1.1.1")})
+	c.Put("b.com", []net.IPAddr{ip("2.2.2.2")})
+
+	a, ok := c.Get("a.com")
+	if !ok || !a[0].IP.Equal(net.ParseIP("1.1.1.1")) {
+		t.Fatalf("a.com: got %v %v", a, ok)
+	}
+	b, ok := c.Get("b.com")
+	if !ok || !b[0].IP.Equal(net.ParseIP("2.2.2.2")) {
+		t.Fatalf("b.com: got %v %v", b, ok)
+	}
+}
+
+func TestMultipleIPs(t *testing.T) {
+	c := New(100, time.Minute)
+	ips := []net.IPAddr{ip("1.1.1.1"), ip("2.2.2.2"), ip("3.3.3.3")}
+	c.Put("multi.com", ips)
+
+	got, ok := c.Get("multi.com")
+	if !ok || len(got) != 3 {
+		t.Fatalf("expected 3 IPs, got %v %v", got, ok)
+	}
+	for i, want := range ips {
+		if !got[i].IP.Equal(want.IP) {
+			t.Fatalf("ip[%d]: got %v, want %v", i, got[i], want)
+		}
+	}
+}
+
+// --- TTL / expiry ---
+
+func TestGetExpired(t *testing.T) {
+	c := New(100, 10*time.Millisecond)
+	c.Put("expire.com", []net.IPAddr{ip("1.1.1.1")})
+	time.Sleep(20 * time.Millisecond)
+
+	got, ok := c.Get("expire.com")
+	if ok || got != nil {
+		t.Fatalf("expected miss after expiry, got %v %v", got, ok)
+	}
+	if c.Len() != 0 {
+		t.Fatalf("expected entry cleaned up, len=%d", c.Len())
+	}
+}
+
+func TestGetNotYetExpired(t *testing.T) {
+	c := New(100, time.Second)
+	c.Put("fresh.com", []net.IPAddr{ip("1.1.1.1")})
+
+	got, ok := c.Get("fresh.com")
+	if !ok {
+		t.Fatal("expected hit within TTL")
+	}
+	if !got[0].IP.Equal(net.ParseIP("1.1.1.1")) {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestPutResetsExpiry(t *testing.T) {
+	c := New(100, 30*time.Millisecond)
+	c.Put("reset.com", []net.IPAddr{ip("1.1.1.1")})
+	time.Sleep(15 * time.Millisecond)
+
+	// Overwrite resets the TTL clock.
+	c.Put("reset.com", []net.IPAddr{ip("2.2.2.2")})
+	time.Sleep(20 * time.Millisecond)
+
+	got, ok := c.Get("reset.com")
+	if !ok {
+		t.Fatal("expected hit after TTL reset")
+	}
+	if !got[0].IP.Equal(net.ParseIP("2.2.2.2")) {
+		t.Fatalf("got %v", got)
+	}
+}
+
+// --- LRU eviction ---
+
+func TestEvictionRemovesLRU(t *testing.T) {
+	c := New(3, time.Minute)
+	c.Put("a.com", []net.IPAddr{ip("1.1.1.1")})
+	c.Put("b.com", []net.IPAddr{ip("2.2.2.2")})
+	c.Put("c.com", []net.IPAddr{ip("3.3.3.3")})
+
+	// This should evict a.com (LRU).
+	c.Put("d.com", []net.IPAddr{ip("4.4.4.4")})
+
+	if _, ok := c.Get("a.com"); ok {
+		t.Fatal("a.com should have been evicted")
+	}
+	for _, d := range []string{"b.com", "c.com", "d.com"} {
+		if _, ok := c.Get(d); !ok {
+			t.Fatalf("%s should still be present", d)
+		}
+	}
+}
+
+func TestGetPromotesToFront(t *testing.T) {
+	c := New(3, time.Minute)
+	c.Put("a.com", []net.IPAddr{ip("1.1.1.1")})
+	c.Put("b.com", []net.IPAddr{ip("2.2.2.2")})
+	c.Put("c.com", []net.IPAddr{ip("3.3.3.3")})
+
+	// Promote a.com to front; b.com is now LRU.
+	c.Get("a.com")
+
+	c.Put("d.com", []net.IPAddr{ip("4.4.4.4")})
+
+	if _, ok := c.Get("b.com"); ok {
+		t.Fatal("b.com should have been evicted (was LRU after a.com promoted)")
+	}
+	if _, ok := c.Get("a.com"); !ok {
+		t.Fatal("a.com should still be present (was promoted)")
+	}
+}
+
+func TestEvictionChain(t *testing.T) {
+	cap := 5
+	c := New(cap, time.Minute)
+	for i := 0; i < cap; i++ {
+		c.Put(strings.Repeat("a", i+1)+".com", []net.IPAddr{ip("1.1.1.1")})
+	}
+	// Insert 10 more; each should evict one.
+	for i := 0; i < 10; i++ {
+		c.Put(strings.Repeat("z", i+1)+".com", []net.IPAddr{ip("9.9.9.9")})
+		if c.Len() != cap {
+			t.Fatalf("after extra insert %d: len=%d, want %d", i, c.Len(), cap)
+		}
+	}
+}
+
+// --- Edge cases ---
+
+func TestEmptyDomainKey(t *testing.T) {
+	c := New(100, time.Minute)
+	c.Put("", []net.IPAddr{ip("1.1.1.1")})
+
+	got, ok := c.Get("")
+	if !ok {
+		t.Fatal("expected hit for empty domain key")
+	}
+	if !got[0].IP.Equal(net.ParseIP("1.1.1.1")) {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestEmptyIPSlice(t *testing.T) {
+	c := New(100, time.Minute)
+	c.Put("x.com", []net.IPAddr{})
+
+	got, ok := c.Get("x.com")
+	if !ok {
+		t.Fatal("expected hit for empty IP slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+
+func TestSingleEntryCapacity(t *testing.T) {
+	c := New(1, time.Minute)
+	c.Put("a.com", []net.IPAddr{ip("1.1.1.1")})
+	c.Put("b.com", []net.IPAddr{ip("2.2.2.2")})
+
+	if _, ok := c.Get("a.com"); ok {
+		t.Fatal("a.com should have been evicted")
+	}
+	if _, ok := c.Get("b.com"); !ok {
+		t.Fatal("b.com should be present")
+	}
+}
+
+func TestIPv4AndIPv6(t *testing.T) {
+	c := New(100, time.Minute)
+	ips := []net.IPAddr{ip("93.184.216.34"), ip("2606:2800:220:1:248:1893:25c8:1946")}
+	c.Put("example.com", ips)
+
+	got, ok := c.Get("example.com")
+	if !ok || len(got) != 2 {
+		t.Fatalf("expected 2 IPs, got %v %v", got, ok)
+	}
+	if !got[0].IP.Equal(ips[0].IP) || !got[1].IP.Equal(ips[1].IP) {
+		t.Fatalf("got %v, want %v", got, ips)
+	}
+}
+
+// --- Construction panics ---
+
+func TestNewPanicsOnZeroCapacity(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for zero capacity")
+		}
+	}()
+	New(0, 5*time.Minute)
+}
+
+func TestNewPanicsOnZeroTTL(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for zero TTL")
+		}
+	}()
+	New(100, 0)
+}
+
+func TestNewPanicsOnNegativeTTL(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative TTL")
+		}
+	}()
+	New(100, -1)
+}
+
+func TestLargeDomainName(t *testing.T) {
+	c := New(100, time.Minute)
+	domain := strings.Repeat("a", 253)
+	c.Put(domain, []net.IPAddr{ip("1.1.1.1")})
+
+	got, ok := c.Get(domain)
+	if !ok {
+		t.Fatal("expected hit for large domain name")
+	}
+	if !got[0].IP.Equal(net.ParseIP("1.1.1.1")) {
+		t.Fatalf("got %v", got)
+	}
+}
+
+// --- Concurrency ---
+
+func TestConcurrentPutGet(t *testing.T) {
+	c := New(1000, time.Minute)
+	domains := []string{"a.com", "b.com", "c.com", "d.com", "e.com"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			d := domains[i%len(domains)]
+			c.Put(d, []net.IPAddr{ip("1.1.1.1")})
+			c.Get(d)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestConcurrentEviction(t *testing.T) {
+	cap := 50
+	c := New(cap, time.Minute)
+	// Pre-fill to capacity.
+	for i := 0; i < cap; i++ {
+		c.Put(strings.Repeat("x", i+1), []net.IPAddr{ip("1.1.1.1")})
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			c.Put(strings.Repeat("y", i+1), []net.IPAddr{ip("2.2.2.2")})
+			if c.Len() > cap {
+				t.Errorf("len %d exceeds capacity %d", c.Len(), cap)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if c.Len() > cap {
+		t.Fatalf("final len %d exceeds capacity %d", c.Len(), cap)
+	}
+}
+
+// --- Security-relevant ---
+
+func TestExpiredEntryNeverReturned(t *testing.T) {
+	c := New(100, 10*time.Millisecond)
+	c.Put("secret.com", []net.IPAddr{ip("10.0.0.1")})
+	time.Sleep(20 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, ok := c.Get("secret.com"); ok {
+				t.Error("expired entry was returned")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestOverwriteIsAtomic(t *testing.T) {
+	c := New(100, time.Minute)
+	oldIPs := []net.IPAddr{ip("1.1.1.1"), ip("2.2.2.2")}
+	newIPs := []net.IPAddr{ip("3.3.3.3"), ip("4.4.4.4")}
+	c.Put("atomic.com", oldIPs)
+
+	var wg sync.WaitGroup
+	// Writer goroutine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.Put("atomic.com", newIPs)
+	}()
+
+	// Reader goroutines.
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, ok := c.Get("atomic.com")
+			if !ok {
+				return
+			}
+			// Must be entirely old or entirely new, never mixed.
+			if len(got) != 2 {
+				t.Errorf("unexpected IP count: %d", len(got))
+				return
+			}
+			first := got[0].IP.String()
+			second := got[1].IP.String()
+			isOld := first == "1.1.1.1" && second == "2.2.2.2"
+			isNew := first == "3.3.3.3" && second == "4.4.4.4"
+			if !isOld && !isNew {
+				t.Errorf("partial update observed: %v", got)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// --- Memory usage ---
+
+func TestMemoryUsageAtCapacity(t *testing.T) {
+	const entries = DefaultMaxEntries
+
+	// Baseline: force GC twice so finalizers run, then read heap.
+	runtime.GC()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	c := New(entries, time.Minute)
+	for i := 0; i < entries; i++ {
+		domain := fmt.Sprintf("domain-%d.example.com.", i)
+		c.Put(domain, []net.IPAddr{ip("1.2.3.4")})
+	}
+
+	runtime.KeepAlive(c)
+	runtime.GC()
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	runtime.KeepAlive(c)
+
+	bytes := after.HeapAlloc - before.HeapAlloc
+	perEntry := bytes / uint64(entries)
+	t.Logf("cache full (%d entries): ~%d MB total, ~%d bytes/entry", entries, bytes/(1024*1024), perEntry)
+
+	// Upper bound: 5 MB for 10k entries (~512 bytes/entry).
+	// Actual usage is ~2.5 MB (~250 bytes/entry).
+	const maxBytes = 5 * 1024 * 1024
+	if bytes > maxBytes {
+		t.Fatalf("memory usage %d bytes exceeds %d byte limit", bytes, maxBytes)
+	}
+}

--- a/pkg/services/dns/dns_test.go
+++ b/pkg/services/dns/dns_test.go
@@ -24,7 +24,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 	var server *Server
 
 	ginkgo.BeforeEach(func() {
-		server, _ = New(nil, nil, []types.Zone{})
+		server, _ = New(nil, nil, []types.Zone{}, nil)
 	})
 
 	ginkgo.It("should add dns zone with ip", func() {
@@ -167,7 +167,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 					},
 				},
 			},
-		})
+		}, nil)
 		server.addZone(types.Zone{
 			Name: "testing.",
 			Records: []types.Record{
@@ -375,7 +375,7 @@ func startDNSServer(upstream upstreamResolver) (string, func(), error) {
 		return "", nil, err
 	}
 
-	server, err := NewWithUpstreamResolver(udpConn, tcpLn, nil, upstream)
+	server, err := NewWithUpstreamResolver(udpConn, tcpLn, nil, upstream, nil)
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
## Summary

- Add `pkg/dnscache`, a thread-safe LRU cache (map + doubly-linked list) with per-entry TTL (5 s) and lazy expiry, capped at 10k entries (~2.5 MB at full load)
- Wire cache into the DNS handler: Type A lookups check the cache first, fall back to upstream on miss, and populate on resolve
- Cache is created in `addServices()` and passed through to `dns.New()`; passing `nil` disables caching

## Why

Go's `net.Resolver` [does not cache DNS lookups](https://github.com/golang/go/issues/24796). Each `LookupIPAddr()` call goes through to the system resolver.

On hosts with a local DNS cache daemon — `systemd-resolved` ([up to 4096 entries, honors upstream TTL up to 2 hours](https://www.ctrl.blog/entry/dns-client-ttl.html)), macOS `mDNSResponder` ([unlimited active entries, min 15 s TTL](https://developer.apple.com/forums/thread/687725)) — repeated lookups are already cheap. Our cache adds no meaningful value there.

On hosts **without** a local cache daemon — glibc's stub resolver (minimal containers, Alpine, some RHEL/Debian setups) — every `LookupIPAddr()` is a real network round trip to the upstream DNS server. Since gvisor-tap-vsock acts as the DNS server for VMs, bursts of repeated queries for the same domain (TLS handshakes, HTTP redirects, retries) each hit upstream. This is where the cache helps.

### Relationship with #609 (SNI-based outbound filtering)

This cache becomes more valuable when coupled with #609. The TCP forwarder's SNI allowlist check needs to correlate a TLS ClientHello hostname with previously resolved IPs. Without this cache, that would require a fresh DNS lookup on every TCP connection. With it, the forwarder calls `cache.Get()` to retrieve the already-resolved IPs — no extra round trip per connection.

### Prior art

Application-level DNS caching with short TTLs is a common pattern when the runtime doesn't cache:
- **Go**: [rs/dnscache](https://github.com/rs/dnscache), [Tailscale's dnscache](https://pkg.go.dev/tailscale.com/net/dnscache), [mercari/go-dnscache](https://pkg.go.dev/go.mercari.io/go-dnscache)
- **Python**: aiohttp's [`TCPConnector`](https://docs.aiohttp.org/en/stable/client_reference.html) enables DNS caching by default with a [10 s TTL](https://docs.aiohttp.org/en/stable/client_advanced.html)

## Design decisions

- **5 s TTL** — short enough to avoid serving stale results to clients without their own cache, long enough to deduplicate bursts
- **LRU eviction** — bounded memory with O(1) Get/Put via map + linked list
- **Lazy expiry** — expired entries are cleaned up on access, no background goroutine
- **nil-safe** — all existing call sites pass `nil` and behave identically to before

## What is NOT included

- **Read side in TCP forwarder** (`cache.Get()` for SNI allowlist checking) — wired in #609

## Test plan

- [x] `go build ./cmd/gvproxy/`
- [x] `go test ./pkg/dnscache/ -count=1 -v` (24 tests: correctness, TTL, LRU, concurrency, security, memory usage)
- [x] `go test ./pkg/services/dns/ -count=1 -v` (all existing tests pass with `nil` cache)
- [x] `go vet ./pkg/...`
- [ ] Manual smoke test with gvproxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)