### PR TITLE
tap: reduce lock contention in switch packet forwarding

### DIFF
--- a/pkg/tap/switch.go
+++ b/pkg/tap/switch.go
@@ -119,9 +119,6 @@ func (e *Switch) tx(pkt *stack.PacketBuffer) error {
 }
 
 func (e *Switch) txPkt(pkt *stack.PacketBuffer) error {
-	e.writeLock.Lock()
-	defer e.writeLock.Unlock()
-
 	e.connLock.Lock()
 	defer e.connLock.Unlock()
 
@@ -174,6 +171,9 @@ func (e *Switch) txPkt(pkt *stack.PacketBuffer) error {
 }
 
 func (e *Switch) txBuf(conn protocolConn, buf []byte) error {
+	e.writeLock.Lock()
+	defer e.writeLock.Unlock()
+
 	if conn.protocolImpl.Stream() {
 		size := conn.protocolImpl.(streamProtocol).Buf()
 		conn.protocolImpl.(streamProtocol).Write(size, len(buf))


### PR DESCRIPTION
## Motivation

During an 8-hour ramendr stress test (100 sequential runs), gvproxy's data path
permanently froze at run 40, breaking the podman VM's network:
https://github.com/RamenDR/ramen/issues/2428

The VM's virtio-net TX queue stopped forwarding packets while gvproxy's
TCP accept loop remained alive. New TCP connections were established but
no data was sent. The registry cache inside the VM became unreachable,
causing image pulls to hang and fall back to upstream — matching reports
of intermittent container pull failures.

We cannot fully explain the permanent freeze (a goroutine dump during
the event would be needed), but inspecting the code revealed several
problems in the switch's packet forwarding:

1. **ENOBUFS retry loop blocks the entire switch.** `txBuf()` retries
   writes in a tight loop on ENOBUFS while the caller holds `connLock`,
   which guards the connection map used by all rx and tx paths. This
   blocks all network activity — including the rx goroutine reading
   packets from the socket — until the kernel frees buffer space.

2. **Unnecessary lock nesting.** `txPkt()` held both `writeLock` and
   `connLock` with `defer`, keeping both locked for the entire transmit
   path including ENOBUFS retries. The locks serve different purposes
   (write serialization vs. connection map access) and don't need to
   overlap.

3. **Unnecessary locking for rx data path.** In the single-VM case
   (e.g., podman on macOS), the rx goroutine enters `txPkt` for every
   broadcast packet (ARP, DHCP). It never actually writes anything (the
   only connection is the source, so it is skipped), but it was blocked
   on `connLock` waiting for the ENOBUFS loop to finish. This stalled
   the rx goroutine, preventing it from reading packets from the socket,
   eventually filling gvproxy's receive buffer and causing the peer
   to drop packets.

## Changes

1. **Move disconnect from txBuf to txPkt** — separate connection
   lifecycle management from the write function, removing txBuf's
   implicit lock ordering dependency.

2. **Move writeLock from txPkt to txBuf** — make txBuf self-contained
   with its own lock, preparing for connLock separation.

3. **Release connLock before writing to connections** — the core fix.
   Snapshot connections under connLock, release it, then write without
   holding connLock. ENOBUFS retries no longer block the entire switch.

4. **Move connLock into disconnect** — simplify callers by letting
   disconnect manage its own locking.

## Test Results

### Setup

- **Host**: macOS 26.2 (M2 Max)
- **VM**: Ubuntu 25.04 via krunkit with TSO offloading (1 vCPU, 1024 MiB)
- **Network**: gvproxy with `--listen-vfkit` unixgram socket
- **krunkit**: v1.1.1 built with libkrun from
  https://github.com/containers/libkrun/pull/556
- **iperf3**: version 3.20, server running inside the VM

All tests ran with no user workloads on the host. Before and after use the
same VM instance, same krunkit, only gvproxy binary is swapped.

Using more vCPUs gives better results since the VM has no workload
competing with the network stack for CPU time.

### Host → VM (single stream, 60s)

```
iperf3 -c localhost -t 60 --json
```

Results: `host-to-vm-before.json`, `host-to-vm-after.json`

<img width="1800" height="750" alt="host-to-vm" src="https://github.com/user-attachments/assets/5f30104d-8811-4aab-8c0d-d08ffad975dd" />

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Avg bitrate | 1.67 Gbits/sec | 1.87 Gbits/sec | **+12%** |

Single stream, host to VM. The "after" line sits consistently above
"before" for the entire 60 seconds with no overlap.

This direction goes through gvproxy's gVisor TCP/IP stack, then
txPkt → txBuf → unixgram socket → VM. The improvement comes from
reduced lock contention: txPkt now holds connLock only for a brief
map lookup before releasing it, instead of holding it through the
entire txBuf write path.

### VM → Host (single stream, 60s)

```
iperf3 -c localhost -R -t 60 --json
```

Results: `vm-to-host-before.json`, `vm-to-host-after.json`

<img width="1800" height="750" alt="vm-to-host" src="https://github.com/user-attachments/assets/7c20f1f7-e701-4bf9-8625-ea2787019b2e" />


| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Avg bitrate | 19.9 Gbits/sec | 20.0 Gbits/sec | ~same |

Single stream, VM to host (iperf3 -R). No meaningful difference.

This direction benefits from krunkit's TSO offloading — packets arrive
as 64 KiB datagrams, so per-packet lock overhead is negligible. The
locking fix has little impact when there's only one large packet to
process at a time.

### Bidirectional (single stream each direction, 60s)

```
iperf3 -c localhost --bidir -t 60 --json
```

Results: `bidir-before.json`, `bidir-after.json`

<img width="1800" height="1200" alt="bidir" src="https://github.com/user-attachments/assets/9622be4f-9dab-4152-a88d-04637ec87f6d" />


| Metric | Before | After | Change |
|--------|--------|-------|--------|
| TX (Host → VM) | 0.87 Gbits/sec | 0.93 Gbits/sec | **+7%** |
| RX (VM → Host) | 11.8 Gbits/sec | 13.4 Gbits/sec | **+13%** |

Bidirectional test with one stream in each direction. Both directions
show clear, consistent improvement over the full 60 seconds.

The RX improvement (+13%) is larger than single-stream because under
bidirectional load, the TX path's ENOBUFS retry loops previously
blocked the RX path from entering txPkt (for broadcast forwarding).
With connLock released before txBuf, the RX goroutine passes through
txPkt without waiting for TX writes to complete.

### Stress Test (8 streams bidir, zero-copy, 10 minutes)

```
iperf3 -c localhost --bidir -Z -P 8 -t 600 --json
```

Results: `stress-before.json`, `stress-after.json`

#### Aggregate throughput

<img width="2100" height="1200" alt="stress-sum" src="https://github.com/user-attachments/assets/dbd4c5e1-40e1-47c2-8d6d-4c25b44205fb" />


| Metric | Before | After | Change |
|--------|--------|-------|--------|
| TX SUM (Host → VM) | 678 Mbits/sec | 695 Mbits/sec | +2.5% |
| RX SUM (VM → Host) | 29.8 Gbits/sec | 28.5 Gbits/sec | -4.5% |
| **Retransmits** | **945** | **249** | **-74%** |

Aggregate throughput is similar, but the "after" curve is notably
smoother and more consistent over the full 10 minutes. The "before"
curve oscillates as streams compete unfairly for locks.

The headline number is **74% fewer retransmits** (945 → 249). Fewer
retransmits means fewer packets were dropped due to gvproxy stalling
under ENOBUFS pressure. This directly addresses the intermittent
container pull failures that motivated this work.

#### Per-stream fairness (VM → Host)

<img width="2100" height="1200" alt="stress-rx-streams" src="https://github.com/user-attachments/assets/6ae71423-eb45-48e0-b211-bb83cb83c03e" />

| Metric | Before | After |
|--------|--------|-------|
| Min stream | 0.884 Gbits/sec | 3.43 Gbits/sec |
| Max stream | 5.06 Gbits/sec | 3.64 Gbits/sec |
| Std dev (σ) | **1.89** | **0.09** |

This is the most striking result. Before: two streams are starved at
0.88 Gbits/sec (5.7x slower than the fastest stream), while other
streams dominate at 5+ Gbits/sec. After: all 8 streams run within
6% of each other.

Standard deviation dropped from 1.89 to 0.09 — a **21x improvement
in fairness**.

With the old code, connLock was held through the ENOBUFS retry loop,
creating lock convoys where some streams consistently lost the race
for the lock. With connLock released before writes, all streams get
equal access to the write path.

#### Per-stream fairness (Host → VM)

<img width="2100" height="1200" alt="stress-tx-streams" src="https://github.com/user-attachments/assets/dbadf22e-e8e1-43bc-86dc-7b05af748e8a" />

| Metric | Before | After |
|--------|--------|-------|
| Min stream | 69.5 Mbits/sec | 64.5 Mbits/sec |
| Max stream | 93.0 Mbits/sec | 102.6 Mbits/sec |
| Std dev (σ) | 9.30 | 17.13 |

Host → VM streams show uneven distribution initially in both runs.
The "after" run converges to a more even distribution in the last
third of the test, while "before" remains spread throughout. The
absolute differences are small (65-103 Mbits/sec range) compared
to the RX direction.

### Summary

| Test | Before | After | Change |
|------|--------|-------|--------|
| Host → VM (60s) | 1.67 Gbits/sec | 1.87 Gbits/sec | **+12%** |
| VM → Host (60s) | 19.9 Gbits/sec | 20.0 Gbits/sec | ~same |
| Bidir TX (60s) | 0.87 Gbits/sec | 0.93 Gbits/sec | **+7%** |
| Bidir RX (60s) | 11.8 Gbits/sec | 13.4 Gbits/sec | **+13%** |
| Stress retransmits (10m) | 945 | 249 | **-74%** |
| Stress RX fairness (10m) | σ=1.89 | σ=0.09 | **21x fairer** |

The locking changes improve throughput in the host → VM direction,
dramatically improve fairness under stress, and reduce packet loss
by 74%. The VM → Host direction (which benefits from TSO offloading)
is unaffected in single-stream tests.

Complete test results: 
[improved-locking.tar.gz](https://github.com/user-attachments/files/25429805/improved-locking.tar.gz)
