### PR TITLE
gvproxy: Fix --log-file having no effect

### DIFF
--- a/cmd/gvproxy/config.go
+++ b/cmd/gvproxy/config.go
@@ -144,6 +144,9 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 	if args.debug {
 		config.LogLevel = "debug"
 	}
+	if args.logFile != "" {
+		config.LogFile = args.logFile
+	}
 
 	// Set log level
 	if logLevel, err := log.ParseLevel(strings.ToLower(config.LogLevel)); err != nil {
@@ -222,9 +225,6 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 	// Default vpnkit mac addresses enabled only for the default mode
 
 	// Patch config with CLI args
-	if args.logFile != "" {
-		config.LogFile = args.logFile
-	}
 	if args.qemuSocket != "" {
 		config.Interfaces.Qemu = args.qemuSocket
 	}


### PR DESCRIPTION
When running gvproxy with --log-file, the log file is always empty, making debugging issues impossible.

Commit c58b9368 ("gvproxy: Enable config file based configuration") moved the --log-file CLI argument override to after logging setup. By the time args.logFile was applied to config.LogFile, the log file had already been opened (or not, since config.LogFile was still empty). This made --log-file silently do nothing.

Move the args.logFile override before logging setup, next to the existing args.debug override, so the log file is correctly created.

Fixes #618 