### PR TITLE
forwarder: reduce UDPConnTrackTimeout from 90s to 10s to prevent socket accumulation under high-frequency UDP load

### DIFF
--- a/pkg/services/forwarder/udp_proxy.go
+++ b/pkg/services/forwarder/udp_proxy.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// UDPConnTrackTimeout is the timeout used for UDP connection tracking
-	UDPConnTrackTimeout = 90 * time.Second
+	UDPConnTrackTimeout = 10 * time.Second
 	// UDPBufSize is the buffer size for the UDP proxy
 	UDPBufSize = 65507
 )


### PR DESCRIPTION
## Description

### Caveat

I'm not a good GO programmer so I'm being upfront here about using AI to help diagnosis and come up with this solution.  Just want to be transparent.  

### Problem

`UDPProxy` tracks connections by source `(IP, port)`. UDP protocols that use a new
ephemeral source port per packet (DNS, NTP) cause a cache miss on every packet —
creating one `net.Conn` and one goroutine per packet, each held open for the full
`UDPConnTrackTimeout` of 90 seconds.

At any meaningful concurrency this compounds quickly. In our case, running 50
concurrent DNS queries from a container caused thousands of open UDP sockets to
accumulate in the `limactl hostagent` process, eventually causing 1000%+ CPU.

The same issue was independently reported with NTP traffic (see linked issue).

### Root cause

```go
const (
    UDPConnTrackTimeout = 90 * time.Second  // held open per unique source port
)
```

Every DNS query uses a new ephemeral source port → cache miss in `connTrackTable`
→ new `net.Conn` → new `replyLoop` goroutine blocking on `SetReadDeadline` for 90s.
Go's netpoll (`kevent`) then polls all open FDs on every iteration, causing the
CPU spike once socket count reaches ~1,500.

### Evidence

Controlled testing confirmed the 90s constant as the **sole mechanism**:

| Pause after burst | FDs recovered to baseline? |
|---|---|
| 60s | ❌ No — sockets still open |
| 90s | ✅ Yes — exact baseline restored |
| 120s | ✅ Yes |
| 150s | ✅ Yes |

FDs return to exact baseline at precisely the ~87-91 second mark every time,
consistent with `UDPConnTrackTimeout` firing as a timer. Full details and
`lsof`/`sample` data in: https://github.com/lima-vm/lima/issues/4666

### Fix

Reduce `UDPConnTrackTimeout` from 90s to 10s. DNS and NTP responses are
immediate (sub-second in practice) — there is no reason to hold the connection
open for 90 seconds.

10 seconds is chosen as a simple conservative fix — long enough to cover any
reasonable DNS/NTP retry cycle with margin, short enough to prevent accumulation.
A more sophisticated solution (configurable timeout, per-protocol handling, or a
bounded connection table with eviction) may be preferable long-term. This PR is
intended to surface the issue and provide a minimal working fix for discussion.

### Testing

Local binary testing was not possible due to macOS code signing constraints on
the test machine. The fix is validated through:
- Controlled behavioral testing confirming `UDPConnTrackTimeout = 90s` as the
  precise mechanism (60s pause = no recovery, 90s pause = full recovery)
- Source code analysis of `pkg/services/forwarder/udp_proxy.go`
- Independent confirmation from a second reporter (NTP traffic, Lima 2.0.3)

### Related

- https://github.com/lima-vm/lima/issues/4666