### PR TITLE
Fix issue where udp_proxy enters a tight loop using 100% cpu

### DIFF
--- a/pkg/services/forwarder/udp_proxy.go
+++ b/pkg/services/forwarder/udp_proxy.go
@@ -79,6 +79,10 @@ func (proxy *UDPProxy) replyLoop(proxyConn net.Conn, clientAddr net.Addr, client
 		_ = proxyConn.SetReadDeadline(time.Now().Add(UDPConnTrackTimeout))
 	again:
 		read, err := proxyConn.Read(readBuf)
+		if read == 0 && err == nil {
+			// treat this condition same as EOF
+			return
+		}
 		if err != nil {
 			if err, ok := err.(*net.OpError); ok && err.Err == syscall.ECONNREFUSED {
 				// This will happen if the last write failed


### PR DESCRIPTION
Fixes the issue discussed in https://github.com/containers/gvisor-tap-vsock/pull/587 where the Read in the replyLoop on macOS is returning 0 with no error causing the replyLoop to start using 100% looping on the read.

@cfergeau mentioned this in unexpected, but can happen in go in corner cases and it is probably fine to return in this case:
https://github.com/golang/go/issues/40385
https://github.com/golang/go/issues/27531

https://github.com/containers/gvisor-tap-vsock/pull/587#issuecomment-4037521240