### PR TITLE
fix config test stdio

### DIFF
--- a/cmd/gvproxy/config.go
+++ b/cmd/gvproxy/config.go
@@ -153,6 +153,14 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 		config.LogFile = args.logFile
 	}
 
+	if args.logFile != "" {
+		config.LogFile = args.logFile
+	}
+
+	if config.LogLevel == "" {
+		config.LogLevel = "info"
+	}
+
 	// Set log level
 	if logLevel, err := log.ParseLevel(strings.ToLower(config.LogLevel)); err != nil {
 		log.Warningf("bad log level \"%s\", falling back to \"info\"", config.LogLevel)
@@ -182,9 +190,6 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 	}
 
 	// Set defaults
-	if config.LogLevel == "" {
-		config.LogLevel = "info"
-	}
 	if config.Stack.MTU == 0 {
 		config.Stack.MTU = 1500
 	}

--- a/cmd/gvproxy/config_test.go
+++ b/cmd/gvproxy/config_test.go
@@ -69,7 +69,7 @@ func TestConfigInit(t *testing.T) {
 		result, errMarshal := yaml.Marshal(cnf)
 		require.NoErrorf(t, errMarshal, "%s: unmarshallable config", v.CaseName)
 
-		assert.YAMLEq(t, v.ResultConfig, string(result), "%s: resulted and expected config mismatch", v.CaseName)
+		assert.YAMLEq(t, v.ResultConfig, string(result), "%s: mismatch between generated and expected config", v.CaseName)
 	}
 }
 

--- a/cmd/gvproxy/config_test.go
+++ b/cmd/gvproxy/config_test.go
@@ -646,6 +646,8 @@ stack:
     mtu: 1500
     subnet: 192.168.127.0/24
     gatewayIP: 192.168.127.1
+    deviceIP: 192.168.127.2
+    hostIP: 192.168.127.254
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     dns:
         - name: containers.internal.
@@ -684,6 +686,8 @@ stack:
     mtu: 1500
     subnet: 192.168.127.0/24
     gatewayIP: 192.168.127.1
+    deviceIP: 192.168.127.2
+    hostIP: 192.168.127.254
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     nat:
         192.168.127.254: 127.0.0.1


### PR DESCRIPTION
PR containers#614 added deviceIP and hostIP fields to the configuration but
missed updating the stdio test cases that were added separately.
This caused TestConfigInit to fail because the actual output now
includes these fields while the expected output didn't.
- **test: fix stdio test cases missing deviceIP and hostIP fields**
- **test: Reword failure message**
- **Fix support for 'log-file' arg**
