### PR TITLE
Remove duplicate check for `log-file`

### DIFF
--- a/cmd/gvproxy/config.go
+++ b/cmd/gvproxy/config.go
@@ -153,10 +153,6 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 		config.LogFile = args.logFile
 	}
 
-	if args.logFile != "" {
-		config.LogFile = args.logFile
-	}
-
 	if config.LogLevel == "" {
 		config.LogLevel = "info"
 	}


### PR DESCRIPTION
c6a56ecb was meant to only move `log-level`, but it also duplicated an
unneeded `log-file` block. This was caught too late in the review
process, the PR was automatically merged before this could be addressed.

Signed-off-by: Christophe Fergeau <cfergeau@redhat.com>
