### PR TITLE
unixgram transport: build for all Unix(-like) platforms again

### DIFF
--- a/pkg/transport/listen_darwin.go
+++ b/pkg/transport/listen_darwin.go
@@ -1,7 +1,6 @@
 package transport
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -30,18 +29,4 @@ func listenURL(parsed *url.URL) (net.Listener, error) {
 	default:
 		return defaultListenURL(parsed)
 	}
-}
-
-func ListenUnixgram(endpoint string) (*net.UnixConn, error) {
-	parsed, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if parsed.Scheme != "unixgram" {
-		return nil, errors.New("unexpected scheme")
-	}
-	return net.ListenUnixgram("unixgram", &net.UnixAddr{
-		Name: parsed.Path,
-		Net:  "unixgram",
-	})
 }

--- a/pkg/transport/unixgram_unix.go
+++ b/pkg/transport/unixgram_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build !windows
 
 package transport
 
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"syscall"
 )
 
@@ -86,6 +87,20 @@ func peekAddress(listeningConn *net.UnixConn) (*net.UnixAddr, error) {
 
 	vfkitAddr := &net.UnixAddr{Name: vfkitSockaddrUnix.Name, Net: "unixgram"}
 	return vfkitAddr, nil
+}
+
+func ListenUnixgram(endpoint string) (*net.UnixConn, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if parsed.Scheme != "unixgram" {
+		return nil, errors.New("unexpected scheme")
+	}
+	return net.ListenUnixgram("unixgram", &net.UnixAddr{
+		Name: parsed.Path,
+		Net:  "unixgram",
+	})
 }
 
 func AcceptVfkit(listeningConn *net.UnixConn) (net.Conn, error) {

--- a/pkg/transport/unixgram_windows.go
+++ b/pkg/transport/unixgram_windows.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build windows
 
 package transport
 


### PR DESCRIPTION
Hello, when using gvproxy in the vfkit unixgram mode, it can talk to real Apple Virtualization framework VMs but also [libkrun](https://github.com/containers/libkrun) which reimplements the same protocol. At first, I was only working on my project which uses libkrun and targets macOS, so everything worked nicely. Now I'm contributing tests to the libkrun project (booting FreeBSD on aarch64) and the thing is, libkrun also works on Linux aarch64. I wanted to use gvproxy as a cross-platform network helper for the test cases but that requires vfkit support to be built on other Unix-like platforms (like it was originally done).

Would you consider merging this change? Thank you.