### PR TITLE
fix: apply ec2MetadataAccess bypass to UDP forwarder for link-local traffic

### DIFF
--- a/cmd/gvproxy/config.go
+++ b/cmd/gvproxy/config.go
@@ -136,7 +136,7 @@ func GvproxyArgParse(flagSet *flag.FlagSet, args *GvproxyArgs, argv []string) (*
 	flagSet.StringVar(&args.pidFile, "pid-file", "", "Generate a file with the PID in it")
 	flagSet.StringVar(&args.logFile, "log-file", "", "Output log messages (logrus) to a given file path")
 	flagSet.StringVar(&args.servicesEndpoint, "services", "", "Exposes the same HTTP API as the --listen flag, without the /connect endpoint")
-	flagSet.BoolVar(&args.ec2MetadataAccess, "ec2-metadata-access", false, "Permits access to EC2 Metadata Service (TCP only)")
+	flagSet.BoolVar(&args.ec2MetadataAccess, "ec2-metadata-access", false, "Permits access to EC2 Metadata Service and Amazon Time Sync Service")
 	flagSet.StringVar(&args.notificationSocket, "notification", "", "Socket to be used to send network-ready notifications")
 	if err := flagSet.Parse(argv); err != nil {
 		return nil, err

--- a/pkg/services/forwarder/udp.go
+++ b/pkg/services/forwarder/udp.go
@@ -18,7 +18,7 @@ func UDP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mute
 	return udp.NewForwarder(s, func(r *udp.ForwarderRequest) bool {
 		localAddress := r.ID().LocalAddress
 
-		if (!ec2MetadataAccess) && (linkLocal().Contains(localAddress) || localAddress == header.IPv4Broadcast) {
+		if (!ec2MetadataAccess) && linkLocal().Contains(localAddress) || (localAddress == header.IPv4Broadcast) {
 			return true
 		}
 

--- a/pkg/services/forwarder/udp.go
+++ b/pkg/services/forwarder/udp.go
@@ -14,11 +14,11 @@ import (
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
-func UDP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mutex) *udp.Forwarder {
+func UDP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mutex, ec2MetadataAccess bool) *udp.Forwarder {
 	return udp.NewForwarder(s, func(r *udp.ForwarderRequest) bool {
 		localAddress := r.ID().LocalAddress
 
-		if linkLocal().Contains(localAddress) || localAddress == header.IPv4Broadcast {
+		if (!ec2MetadataAccess) && (linkLocal().Contains(localAddress) || localAddress == header.IPv4Broadcast) {
 			return true
 		}
 

--- a/pkg/virtualnetwork/services.go
+++ b/pkg/virtualnetwork/services.go
@@ -27,7 +27,7 @@ func addServices(configuration *types.Configuration, s *stack.Stack, ipPool *tap
 
 	tcpForwarder := forwarder.TCP(s, translation, &natLock, configuration.Ec2MetadataAccess)
 	s.SetTransportProtocolHandler(tcp.ProtocolNumber, tcpForwarder.HandlePacket)
-	udpForwarder := forwarder.UDP(s, translation, &natLock)
+	udpForwarder := forwarder.UDP(s, translation, &natLock, configuration.Ec2MetadataAccess)
 	s.SetTransportProtocolHandler(udp.ProtocolNumber, udpForwarder.HandlePacket)
 	icmpForwarder := forwarder.ICMP(s, translation, &natLock)
 	s.SetTransportProtocolHandler(icmp.ProtocolNumber4, icmpForwarder.HandlePacket)


### PR DESCRIPTION
The TCP forwarder allows link-local (169.254.0.0/16) traffic when ec2MetadataAccess is enabled, but the UDP forwarder unconditionally blocks it. This prevents UDP services on link-local addresses, such as NTP via the Amazon Time Sync Service (169.254.169.123), from functioning even when properly configured in the NAT table.