### PR TITLE
lint: suppress new gosec taint analysis warnings

### DIFF
--- a/cmd/qemu-wrapper/main.go
+++ b/cmd/qemu-wrapper/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	conn, err := net.Dial("unix", os.Args[1])
+	conn, err := net.Dial("unix", os.Args[1]) // #nosec G704 - internal utility with controlled socket path
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -16,7 +16,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	cmd := exec.Command(os.Args[2], os.Args[3:]...) // #nosec G204
+	cmd := exec.Command(os.Args[2], os.Args[3:]...) // #nosec G204 G702 - internal utility with controlled arguments
 	cmd.ExtraFiles = append(cmd.ExtraFiles, fd)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/pkg/sshclient/ssh_forwarder.go
+++ b/pkg/sshclient/ssh_forwarder.go
@@ -116,7 +116,7 @@ func listenUnix(socketURI *url.URL) (net.Listener, error) {
 		path = strings.TrimPrefix(path, "/")
 	}
 
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) { // #nosec G703 - validated URL path for socket cleanup
 		return nil, err
 	}
 

--- a/pkg/transport/listen_darwin.go
+++ b/pkg/transport/listen_darwin.go
@@ -20,7 +20,7 @@ func listenURL(parsed *url.URL) (net.Listener, error) {
 			return nil, err
 		}
 		path := path.Join(parsed.Path, fmt.Sprintf("00000002.%08x", port))
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) { // #nosec G703 - constructed path for socket cleanup
 			return nil, err
 		}
 		return net.ListenUnix("unix", &net.UnixAddr{

--- a/pkg/transport/unixgram_darwin.go
+++ b/pkg/transport/unixgram_darwin.go
@@ -21,10 +21,10 @@ func connectListeningUnixgramConn(conn *net.UnixConn, remoteAddr *net.UnixAddr) 
 		return nil, err
 	}
 	err = rawConn.Control(func(fd uintptr) {
-		if err = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_SNDBUF, 1*1024*1024); err != nil {
+		if err = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_SNDBUF, 1*1024*1024); err != nil { // #nosec G115 - fd always fits in int
 			return
 		}
-		if err = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, 4*1024*1024); err != nil {
+		if err = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, 4*1024*1024); err != nil { // #nosec G115 - fd always fits in int
 			return
 		}
 	})
@@ -57,7 +57,7 @@ func peekAddress(listeningConn *net.UnixConn) (*net.UnixAddr, error) {
 
 	magic := make([]byte, 4)
 	getRemoteAddr := func(fd uintptr) bool {
-		_, vfkitSockaddr, getRemoteAddrErr = syscall.Recvfrom(int(fd), magic, syscall.MSG_PEEK|syscall.MSG_TRUNC)
+		_, vfkitSockaddr, getRemoteAddrErr = syscall.Recvfrom(int(fd), magic, syscall.MSG_PEEK|syscall.MSG_TRUNC) // #nosec G115 - fd always fits in int
 
 		return !errors.Is(getRemoteAddrErr, syscall.EAGAIN)
 	}


### PR DESCRIPTION
Add #nosec directives with explanations for warnings introduced by golangci-lint 2.11.4's enhanced taint analysis:

- G704 (SSRF): unix socket dial in qemu-wrapper uses controlled paths
- G702 (command injection): exec.Command in qemu-wrapper uses controlled args
- G703 (path traversal): os.Remove calls are for socket cleanup with validated paths
- G115 (integer overflow): uintptr to int conversions for fd are safe on darwin

All flagged code paths use internally controlled or validated inputs, not user-supplied data.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>