### PR TITLE
forwarder: improve error message for port conflicts

### DIFF
--- a/pkg/services/forwarder/ports.go
+++ b/pkg/services/forwarder/ports.go
@@ -70,8 +70,9 @@ func NewPortsForwarder(s *stack.Stack) *PortsForwarder {
 func (f *PortsForwarder) Expose(protocol types.TransportProtocol, local, remote string) error {
 	f.proxiesLock.Lock()
 	defer f.proxiesLock.Unlock()
+
 	if _, ok := f.proxies[key(protocol, local)]; ok {
-		return errors.New("proxy already running")
+		return fmt.Errorf("proxy already running for %s on %s", protocol, local)
 	}
 
 	switch protocol {


### PR DESCRIPTION
Fixes #615

When attempting to expose a port that is already in use, the error message now includes the protocol and local address to help users identify and resolve the conflict.