### PR TITLE
Log security-relevant gvproxy services API requests

### DIFF
--- a/pkg/apilog/log.go
+++ b/pkg/apilog/log.go
@@ -1,0 +1,20 @@
+package apilog
+
+import (
+	"maps"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func LogEvent(r *http.Request, endpoint, operation, outcome string, extra log.Fields) {
+	fields := log.Fields{
+		"component": "services-api",
+		"endpoint":  endpoint,
+		"operation": operation,
+		"source":    r.RemoteAddr,
+		"outcome":   outcome,
+	}
+	maps.Copy(fields, extra)
+	log.WithFields(fields).Info("gvproxy API request")
+}

--- a/pkg/apilog/log.go
+++ b/pkg/apilog/log.go
@@ -1,0 +1,20 @@
+package apilog
+
+import (
+	"maps"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func LogEvent(r *http.Request, endpoint, outcome string, extra log.Fields) {
+	fields := log.Fields{
+		"component": "services-api",
+		"endpoint":  endpoint,
+		"method":    r.Method,
+		"source":    r.RemoteAddr,
+		"outcome":   outcome,
+	}
+	maps.Copy(fields, extra)
+	log.WithFields(fields).Info("gvproxy API request")
+}

--- a/pkg/services/dhcp/dhcp.go
+++ b/pkg/services/dhcp/dhcp.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/apilog"
 	"github.com/containers/gvisor-tap-vsock/pkg/tap"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/insomniacslk/dhcp/dhcpv4"
@@ -130,7 +131,8 @@ func (s *Server) Serve() error {
 
 func (s *Server) Mux() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/leases", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/leases", func(w http.ResponseWriter, r *http.Request) {
+		apilog.LogEvent(r, "/services/dhcp/leases", "list_leases", "success", nil)
 		_ = json.NewEncoder(w).Encode(s.IPPool.Leases())
 	})
 	return mux

--- a/pkg/services/dhcp/dhcp.go
+++ b/pkg/services/dhcp/dhcp.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/apilog"
 	"github.com/containers/gvisor-tap-vsock/pkg/tap"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/insomniacslk/dhcp/dhcpv4"
@@ -130,7 +131,8 @@ func (s *Server) Serve() error {
 
 func (s *Server) Mux() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/leases", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/leases", func(w http.ResponseWriter, r *http.Request) {
+		apilog.LogEvent(r, "/services/dhcp/leases", "success", nil)
 		_ = json.NewEncoder(w).Encode(s.IPPool.Leases())
 	})
 	return mux

--- a/pkg/services/dns/dns.go
+++ b/pkg/services/dns/dns.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/apilog"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
@@ -295,6 +296,9 @@ func (s *Server) Mux() http.Handler {
 		}
 
 		s.addZone(req)
+		apilog.LogEvent(r, "/services/dns/add", "add_zone", "success", log.Fields{
+			"zone": req.Name,
+		})
 		w.WriteHeader(http.StatusOK)
 	})
 	return mux

--- a/pkg/services/dns/dns.go
+++ b/pkg/services/dns/dns.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/apilog"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
@@ -282,10 +283,12 @@ func (s *Server) ServeTCP() error {
 
 func (s *Server) Mux() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/all", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/all", func(w http.ResponseWriter, r *http.Request) {
 		s.handler.zonesLock.RLock()
-		_ = json.NewEncoder(w).Encode(s.handler.zones)
+		zones := s.handler.zones
+		_ = json.NewEncoder(w).Encode(zones)
 		s.handler.zonesLock.RUnlock()
+		apilog.LogEvent(r, "/services/dns/all", "success", nil)
 	})
 
 	mux.HandleFunc("/add", func(w http.ResponseWriter, r *http.Request) {
@@ -308,6 +311,9 @@ func (s *Server) Mux() http.Handler {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		apilog.LogEvent(r, "/services/dns/add", "success", log.Fields{
+			"zone": req.Name,
+		})
 		w.WriteHeader(http.StatusOK)
 	})
 	return mux

--- a/pkg/services/dns/dns.go
+++ b/pkg/services/dns/dns.go
@@ -293,21 +293,35 @@ func (s *Server) Mux() http.Handler {
 
 	mux.HandleFunc("/add", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
+			apilog.LogEvent(r, "/services/dns/add", "error", log.Fields{
+				"error": "post only",
+			})
 			http.Error(w, "post only", http.StatusBadRequest)
 			return
 		}
 		var req types.Zone
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apilog.LogEvent(r, "/services/dns/add", "error", log.Fields{
+				"error": err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
 		if err := s.validateZone(req); err != nil {
+			apilog.LogEvent(r, "/services/dns/add", "error", log.Fields{
+				"zone":  req.Name,
+				"error": err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
 		if err := s.addZone(req); err != nil {
+			apilog.LogEvent(r, "/services/dns/add", "error", log.Fields{
+				"zone":  req.Name,
+				"error": err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/pkg/services/forwarder/ports.go
+++ b/pkg/services/forwarder/ports.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/apilog"
 	"github.com/containers/gvisor-tap-vsock/pkg/sshclient"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/inetaf/tcpproxy"
@@ -322,6 +323,11 @@ func (f *PortsForwarder) Mux() http.Handler {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		apilog.LogEvent(r, "/services/forwarder/expose", "expose", "success", log.Fields{
+			"protocol": req.Protocol,
+			"local":    req.Local,
+			"remote":   remoteAddr,
+		})
 		w.WriteHeader(http.StatusOK)
 	})
 	mux.HandleFunc("/unexpose", func(w http.ResponseWriter, r *http.Request) {
@@ -341,6 +347,10 @@ func (f *PortsForwarder) Mux() http.Handler {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		apilog.LogEvent(r, "/services/forwarder/unexpose", "unexpose", "success", log.Fields{
+			"protocol": req.Protocol,
+			"local":    req.Local,
+		})
 		w.WriteHeader(http.StatusOK)
 	})
 	return mux

--- a/pkg/services/forwarder/ports.go
+++ b/pkg/services/forwarder/ports.go
@@ -305,11 +305,17 @@ func (f *PortsForwarder) Mux() http.Handler {
 	})
 	mux.HandleFunc("/expose", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
+			apilog.LogEvent(r, "/services/forwarder/expose", "error", log.Fields{
+				"error": "post only",
+			})
 			http.Error(w, "post only", http.StatusBadRequest)
 			return
 		}
 		var req types.ExposeRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apilog.LogEvent(r, "/services/forwarder/expose", "error", log.Fields{
+				"error": err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -325,12 +331,24 @@ func (f *PortsForwarder) Mux() http.Handler {
 			var err error
 			remoteAddr, err = remote(req, r.RemoteAddr)
 			if err != nil {
+				apilog.LogEvent(r, "/services/forwarder/expose", "error", log.Fields{
+					"protocol": req.Protocol,
+					"local":    req.Local,
+					"remote":   req.Remote,
+					"error":    err.Error(),
+				})
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
 		}
 
 		if err := f.Expose(req.Protocol, req.Local, remoteAddr); err != nil {
+			apilog.LogEvent(r, "/services/forwarder/expose", "error", log.Fields{
+				"protocol": req.Protocol,
+				"local":    req.Local,
+				"remote":   remoteAddr,
+				"error":    err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -343,11 +361,17 @@ func (f *PortsForwarder) Mux() http.Handler {
 	})
 	mux.HandleFunc("/unexpose", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
+			apilog.LogEvent(r, "/services/forwarder/unexpose", "error", log.Fields{
+				"error": "post only",
+			})
 			http.Error(w, "post only", http.StatusBadRequest)
 			return
 		}
 		var req types.UnexposeRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apilog.LogEvent(r, "/services/forwarder/unexpose", "error", log.Fields{
+				"error": err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -355,6 +379,11 @@ func (f *PortsForwarder) Mux() http.Handler {
 			req.Protocol = types.TCP
 		}
 		if err := f.Unexpose(req.Protocol, req.Local); err != nil {
+			apilog.LogEvent(r, "/services/forwarder/unexpose", "error", log.Fields{
+				"protocol": req.Protocol,
+				"local":    req.Local,
+				"error":    err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/pkg/services/forwarder/ports.go
+++ b/pkg/services/forwarder/ports.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/apilog"
 	"github.com/containers/gvisor-tap-vsock/pkg/sshclient"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/inetaf/tcpproxy"
@@ -286,7 +287,7 @@ func (f *PortsForwarder) Unexpose(protocol types.TransportProtocol, local string
 
 func (f *PortsForwarder) Mux() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/all", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/all", func(w http.ResponseWriter, r *http.Request) {
 		f.proxiesLock.Lock()
 		defer f.proxiesLock.Unlock()
 		ret := make([]proxy, 0)
@@ -300,6 +301,7 @@ func (f *PortsForwarder) Mux() http.Handler {
 			return ret[i].Local < ret[j].Local
 		})
 		_ = json.NewEncoder(w).Encode(ret)
+		apilog.LogEvent(r, "/services/forwarder/all", "success", nil)
 	})
 	mux.HandleFunc("/expose", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -332,6 +334,11 @@ func (f *PortsForwarder) Mux() http.Handler {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		apilog.LogEvent(r, "/services/forwarder/expose", "success", log.Fields{
+			"protocol": req.Protocol,
+			"local":    req.Local,
+			"remote":   remoteAddr,
+		})
 		w.WriteHeader(http.StatusOK)
 	})
 	mux.HandleFunc("/unexpose", func(w http.ResponseWriter, r *http.Request) {
@@ -351,6 +358,10 @@ func (f *PortsForwarder) Mux() http.Handler {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		apilog.LogEvent(r, "/services/forwarder/unexpose", "success", log.Fields{
+			"protocol": req.Protocol,
+			"local":    req.Local,
+		})
 		w.WriteHeader(http.StatusOK)
 	})
 	return mux

--- a/pkg/virtualnetwork/mux.go
+++ b/pkg/virtualnetwork/mux.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/apilog"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/inetaf/tcpproxy"
 	log "github.com/sirupsen/logrus"
@@ -24,7 +25,8 @@ func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 	mux.HandleFunc("/cam", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(n.networkSwitch.CAM())
 	})
-	mux.HandleFunc("/leases", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/leases", func(w http.ResponseWriter, r *http.Request) {
+		apilog.LogEvent(r, "/leases", "list_leases", "success", nil)
 		_ = json.NewEncoder(w).Encode(n.ipPool.Leases())
 	})
 	mux.HandleFunc("/tunnel", func(w http.ResponseWriter, r *http.Request) {
@@ -62,6 +64,10 @@ func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		apilog.LogEvent(r, "/tunnel", "open_tunnel", "success", log.Fields{
+			"ip":   ip,
+			"port": port16,
+		})
 
 		remote := tcpproxy.DialProxy{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {

--- a/pkg/virtualnetwork/mux.go
+++ b/pkg/virtualnetwork/mux.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/apilog"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/inetaf/tcpproxy"
 	log "github.com/sirupsen/logrus"
@@ -18,13 +19,19 @@ import (
 func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.Handle("/services/", http.StripPrefix("/services", n.servicesMux))
-	mux.HandleFunc("/stats", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(statsAsJSON(n.networkSwitch.Sent, n.networkSwitch.Received, n.stack.Stats()))
+		apilog.LogEvent(r, "/stats", "success", nil)
 	})
-	mux.HandleFunc("/cam", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(n.networkSwitch.CAM())
+	mux.HandleFunc("/cam", func(w http.ResponseWriter, r *http.Request) {
+		cam := n.networkSwitch.CAM()
+		_ = json.NewEncoder(w).Encode(cam)
+		apilog.LogEvent(r, "/cam", "success", log.Fields{
+			"entries": len(cam),
+		})
 	})
-	mux.HandleFunc("/leases", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/leases", func(w http.ResponseWriter, r *http.Request) {
+		apilog.LogEvent(r, "/leases", "success", nil)
 		_ = json.NewEncoder(w).Encode(n.ipPool.Leases())
 	})
 	mux.HandleFunc("/tunnel", func(w http.ResponseWriter, r *http.Request) {
@@ -62,6 +69,10 @@ func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		apilog.LogEvent(r, "/tunnel", "success", log.Fields{
+			"ip":   ip,
+			"port": port16,
+		})
 
 		remote := tcpproxy.DialProxy{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
@@ -82,7 +93,7 @@ func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 
 func (n *VirtualNetwork) Mux() *http.ServeMux {
 	mux := n.ServicesMux()
-	mux.HandleFunc(types.ConnectPath, func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc(types.ConnectPath, func(w http.ResponseWriter, r *http.Request) {
 		hj, ok := w.(http.Hijacker)
 		if !ok {
 			http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)
@@ -100,6 +111,9 @@ func (n *VirtualNetwork) Mux() *http.ServeMux {
 			return
 		}
 
+		apilog.LogEvent(r, types.ConnectPath, "success", log.Fields{
+			"protocol": n.configuration.Protocol,
+		})
 		_ = n.networkSwitch.Accept(context.Background(), conn, n.configuration.Protocol)
 	})
 	return mux

--- a/pkg/virtualnetwork/mux.go
+++ b/pkg/virtualnetwork/mux.go
@@ -37,11 +37,18 @@ func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 	mux.HandleFunc("/tunnel", func(w http.ResponseWriter, r *http.Request) {
 		ip := r.URL.Query().Get("ip")
 		if ip == "" {
+			apilog.LogEvent(r, "/tunnel", "error", log.Fields{
+				"error": "ip is mandatory",
+			})
 			http.Error(w, "ip is mandatory", http.StatusInternalServerError)
 			return
 		}
 		port, err := strconv.ParseUint(r.URL.Query().Get("port"), 10, 16)
 		if err != nil {
+			apilog.LogEvent(r, "/tunnel", "error", log.Fields{
+				"ip":    ip,
+				"error": err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -49,23 +56,43 @@ func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 
 		hj, ok := w.(http.Hijacker)
 		if !ok {
+			apilog.LogEvent(r, "/tunnel", "error", log.Fields{
+				"ip":    ip,
+				"port":  port16,
+				"error": "webserver doesn't support hijacking",
+			})
 			http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)
 			return
 		}
 
 		conn, bufrw, err := hj.Hijack()
 		if err != nil {
+			apilog.LogEvent(r, "/tunnel", "error", log.Fields{
+				"ip":    ip,
+				"port":  port16,
+				"error": err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		defer conn.Close()
 
 		if err := bufrw.Flush(); err != nil {
+			apilog.LogEvent(r, "/tunnel", "error", log.Fields{
+				"ip":    ip,
+				"port":  port16,
+				"error": err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
 		if _, err := conn.Write([]byte(`OK`)); err != nil {
+			apilog.LogEvent(r, "/tunnel", "error", log.Fields{
+				"ip":    ip,
+				"port":  port16,
+				"error": err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -96,17 +123,29 @@ func (n *VirtualNetwork) Mux() *http.ServeMux {
 	mux.HandleFunc(types.ConnectPath, func(w http.ResponseWriter, r *http.Request) {
 		hj, ok := w.(http.Hijacker)
 		if !ok {
+			apilog.LogEvent(r, types.ConnectPath, "error", log.Fields{
+				"protocol": n.configuration.Protocol,
+				"error":    "webserver doesn't support hijacking",
+			})
 			http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)
 			return
 		}
 		conn, bufrw, err := hj.Hijack()
 		if err != nil {
+			apilog.LogEvent(r, types.ConnectPath, "error", log.Fields{
+				"protocol": n.configuration.Protocol,
+				"error":    err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		defer conn.Close()
 
 		if err := bufrw.Flush(); err != nil {
+			apilog.LogEvent(r, types.ConnectPath, "error", log.Fields{
+				"protocol": n.configuration.Protocol,
+				"error":    err.Error(),
+			})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -114,7 +153,12 @@ func (n *VirtualNetwork) Mux() *http.ServeMux {
 		apilog.LogEvent(r, types.ConnectPath, "success", log.Fields{
 			"protocol": n.configuration.Protocol,
 		})
-		_ = n.networkSwitch.Accept(context.Background(), conn, n.configuration.Protocol)
+		if err := n.networkSwitch.Accept(context.Background(), conn, n.configuration.Protocol); err != nil {
+			apilog.LogEvent(r, types.ConnectPath, "error", log.Fields{
+				"protocol": n.configuration.Protocol,
+				"error":    err.Error(),
+			})
+		}
 	})
 	return mux
 }


### PR DESCRIPTION
Tested as follows:

### Terminal 1:
```bash
# terminal-2 (gvproxy)
bin/gvproxy --services unix://$SOCK
INFO[0000] gvproxy version v0.8.8-163-gbf019705
INFO[0000] waiting for clients...
INFO[0000] enabling services API. Listening unix:///tmp/gv-services.sock
INFO[0012] gvproxy API request                           component=services-api endpoint=/stats method=GET outcome=success source=
INFO[0012] gvproxy API request                           component=services-api endpoint=/cam entries=0 method=GET outcome=success source=
INFO[0012] gvproxy API request                           component=services-api endpoint=/leases method=GET outcome=success source=
INFO[0012] gvproxy API request                           component=services-api endpoint=/services/dhcp/leases method=GET outcome=success source=
INFO[0012] gvproxy API request                           component=services-api endpoint=/services/forwarder/all method=GET outcome=success source=
INFO[0013] gvproxy API request                           component=services-api endpoint=/services/dns/all method=GET outcome=success source=
INFO[0013] gvproxy API request                           component=services-api endpoint=/services/dns/add method=POST outcome=success source= zone=test.local.
INFO[0013] gvproxy API request                           component=services-api endpoint=/services/forwarder/expose local=":19090" method=POST outcome=success protocol=tcp remote="127.0.0.1:8080" source=
ERRO[0013] accept tcp [::]:19090: use of closed network connection
INFO[0013] gvproxy API request                           component=services-api endpoint=/services/forwarder/unexpose local=":19090" method=POST outcome=success protocol=tcp source=
INFO[0013] gvproxy API request                           component=services-api endpoint=/tunnel ip=127.0.0.1 method=GET outcome=success port=1 source=
ERRO[0016] cannot dial: connect tcp 127.0.0.1:1: no route to host
INFO[0029] gvproxy API request                           component=services-api endpoint=/services/forwarder/expose error="post only" method=GET outcome=error source=
INFO[0029] gvproxy API request                           component=services-api endpoint=/services/forwarder/expose error="invalid character 'b' looking for beginning of object key string" method=POST outcome=error source=
INFO[0029] gvproxy API request                           component=services-api endpoint=/services/forwarder/unexpose error="proxy not found" local=":65535" method=POST outcome=error protocol=tcp source=
INFO[0029] gvproxy API request                           component=services-api endpoint=/services/dns/add error="post only" method=GET outcome=error source=
INFO[0029] gvproxy API request                           component=services-api endpoint=/services/dns/add error="invalid character 'b' looking for beginning of object key string" method=POST outcome=error source=
INFO[0029] gvproxy API request                           component=services-api endpoint=/services/dns/add error="zone name must be fully qualified (end with '.'): not-fqdn" method=POST outcome=error source= zone=not-fqdn
INFO[0029] gvproxy API request                           component=services-api endpoint=/tunnel error="ip is mandatory" method=GET outcome=error source=
INFO[0029] gvproxy API request                           component=services-api endpoint=/tunnel error="strconv.ParseUint: parsing \"bad\": invalid syntax" ip=127.0.0.1 method=GET outcome=error source=
```

### Terminal 2:

```bash
SOCK=/tmp/gv-services.sock

$ curl -sS --unix-socket "$SOCK" http://unix/stats
{"ARP":{"DisabledPacketsReceived":0,...},"UDP":{"ChecksumErrors":0,"MalformedPacketsReceived":0,"PacketSendErrors":0,"PacketsReceived":0,"PacketsSent":0,"ReceiveBufferErrors":0,"UnknownPortErrors":0}}
gvproxy: INFO ... endpoint=/stats method=GET outcome=success source=

$ curl -sS --unix-socket "$SOCK" http://unix/cam
{}
gvproxy: INFO ... endpoint=/cam entries=0 method=GET outcome=success source=

$ curl -sS --unix-socket "$SOCK" http://unix/leases
{"192.168.127.1":"5a:94:ef:e4:0c:dd","192.168.127.2":"5a:94:ef:e4:0c:ee"}
gvproxy: INFO ... endpoint=/leases method=GET outcome=success source=

$ curl -sS --unix-socket "$SOCK" http://unix/services/dhcp/leases
{"192.168.127.1":"5a:94:ef:e4:0c:dd","192.168.127.2":"5a:94:ef:e4:0c:ee"}
gvproxy: INFO ... endpoint=/services/dhcp/leases method=GET outcome=success source=

$ curl -sS --unix-socket "$SOCK" http://unix/services/forwarder/all
[{"local":"127.0.0.1:2222","remote":"192.168.127.2:22","protocol":"tcp"}]
gvproxy: INFO ... endpoint=/services/forwarder/all method=GET outcome=success source=

$ curl -sS --unix-socket "$SOCK" http://unix/services/dns/all
[{"Name":"containers.internal.","Records":[{"Name":"gateway","IP":"192.168.127.1"},{"Name":"host","IP":"192.168.127.254"}],"DefaultIP":"","Protected":true},{"Name":"docker.internal.","Records":[{"Name":"gateway","IP":"192.168.127.1"},{"Name":"host","IP":"192.168.127.254"}],"DefaultIP":"","Protected":true}]
gvproxy: INFO ... endpoint=/services/dns/all method=GET outcome=success source=

$ curl -sS --unix-socket "$SOCK" -X POST http://unix/services/dns/add -d '{"name":"test.local.","records":[{"name":"api","ip":"10.0.2.2"}]}'
(no response body)
gvproxy: INFO ... endpoint=/services/dns/add method=POST outcome=success source= zone=test.local.

$ curl -sS --unix-socket "$SOCK" -X POST http://unix/services/forwarder/expose -d '{"local":":19090","remote":"127.0.0.1:8080","protocol":"tcp"}'
(no response body)
gvproxy: INFO ... endpoint=/services/forwarder/expose local=":19090" method=POST outcome=success protocol=tcp remote="127.0.0.1:8080" source=
gvproxy: ERRO ... accept tcp [::]:19090: use of closed network connection

$ curl -sS --unix-socket "$SOCK" -X POST http://unix/services/forwarder/unexpose -d '{"local":":19090","protocol":"tcp"}'
(no response body)
gvproxy: INFO ... endpoint=/services/forwarder/unexpose local=":19090" method=POST outcome=success protocol=tcp source=

$ curl -v --unix-socket "$SOCK" "http://unix/tunnel?ip=127.0.0.1&port=1"
* Received HTTP/0.9 when not allowed
curl: (1) Received HTTP/0.9 when not allowed
gvproxy: INFO ... endpoint=/tunnel ip=127.0.0.1 method=GET outcome=success port=1 source=
gvproxy: ERRO ... cannot dial: connect tcp 127.0.0.1:1: no route to host

$ curl -sS --unix-socket "$SOCK" http://unix/services/forwarder/expose
post only
gvproxy: INFO ... endpoint=/services/forwarder/expose error="post only" method=GET outcome=error source=

$ curl -sS --unix-socket "$SOCK" -X POST http://unix/services/forwarder/expose -d '{bad-json}'
invalid character 'b' looking for beginning of object key string
gvproxy: INFO ... endpoint=/services/forwarder/expose error="invalid character 'b' looking for beginning of object key string" method=POST outcome=error source=

$ curl -sS --unix-socket "$SOCK" -X POST http://unix/services/forwarder/unexpose -d '{"local":":65535","protocol":"tcp"}'
proxy not found
gvproxy: INFO ... endpoint=/services/forwarder/unexpose error="proxy not found" local=":65535" method=POST outcome=error protocol=tcp source=

$ curl -sS --unix-socket "$SOCK" http://unix/services/dns/add
post only
gvproxy: INFO ... endpoint=/services/dns/add error="post only" method=GET outcome=error source=

$ curl -sS --unix-socket "$SOCK" -X POST http://unix/services/dns/add -d '{bad-json}'
invalid character 'b' looking for beginning of object key string
gvproxy: INFO ... endpoint=/services/dns/add error="invalid character 'b' looking for beginning of object key string" method=POST outcome=error source=

$ curl -sS --unix-socket "$SOCK" -X POST http://unix/services/dns/add -d '{"name":"not-fqdn","records":[]}'
zone name must be fully qualified (end with '.'): not-fqdn
gvproxy: INFO ... endpoint=/services/dns/add error="zone name must be fully qualified (end with '.'): not-fqdn" method=POST outcome=error source= zone=not-fqdn

$ curl -v --unix-socket "$SOCK" "http://unix/tunnel?port=1"
< HTTP/1.1 500 Internal Server Error
ip is mandatory
gvproxy: INFO ... endpoint=/tunnel error="ip is mandatory" method=GET outcome=error source=

$ curl -v --unix-socket "$SOCK" "http://unix/tunnel?ip=127.0.0.1&port=bad"
< HTTP/1.1 500 Internal Server Error
strconv.ParseUint: parsing "bad": invalid syntax
gvproxy: INFO ... endpoint=/tunnel error="strconv.ParseUint: parsing \"bad\": invalid syntax" ip=127.0.0.1 method=GET outcome=error source=
```