### PR TITLE
prevent arbitrary file deletion via unix socket creation (RHDESK-550)

### DIFF
--- a/cmd/gvproxy/config.go
+++ b/cmd/gvproxy/config.go
@@ -24,30 +24,31 @@ const (
 )
 
 type GvproxyArgs struct {
-	config             string
-	endpoints          arrayFlags
-	debug              bool
-	mtu                int
-	sshPort            int
-	subnet             string
-	gatewayIP          string
-	deviceIP           string
-	hostIP             string
-	vpnkitSocket       string
-	qemuSocket         string
-	bessSocket         string
-	stdioSocket        string
-	vfkitSocket        string
-	notificationSocket string
-	forwardSocket      arrayFlags
-	forwardDest        arrayFlags
-	forwardUser        arrayFlags
-	forwardIdentify    arrayFlags
-	pidFile            string
-	pcapFile           string
-	logFile            string
-	servicesEndpoint   string
-	ec2MetadataAccess  bool
+	config                    string
+	endpoints                 arrayFlags
+	debug                     bool
+	mtu                       int
+	sshPort                   int
+	subnet                    string
+	gatewayIP                 string
+	deviceIP                  string
+	hostIP                    string
+	vpnkitSocket              string
+	qemuSocket                string
+	bessSocket                string
+	stdioSocket               string
+	vfkitSocket               string
+	notificationSocket        string
+	forwardSocket             arrayFlags
+	forwardDest               arrayFlags
+	forwardUser               arrayFlags
+	forwardIdentify           arrayFlags
+	pidFile                   string
+	pcapFile                  string
+	logFile                   string
+	servicesEndpoint          string
+	ec2MetadataAccess         bool
+	gatewayExposeAllProtocols bool
 }
 
 type GvproxyConfig struct {
@@ -61,12 +62,13 @@ type GvproxyConfig struct {
 		Stdio  string `yaml:"stdio,omitempty"`
 		Vfkit  string `yaml:"vfkit,omitempty"`
 	} `yaml:"interfaces,omitempty"`
-	Forwards           []GvproxyConfigForward `yaml:"forwards,omitempty"`
-	PIDFile            string                 `yaml:"pid-file,omitempty"`
-	LogFile            string                 `yaml:"log-file,omitempty"`
-	Services           string                 `yaml:"services,omitempty"`
-	Ec2MetadataAccess  bool                   `yaml:"ec2-metadata-access,omitempty"`
-	NotificationSocket string                 `yaml:"notification,omitempty"`
+	Forwards                  []GvproxyConfigForward `yaml:"forwards,omitempty"`
+	PIDFile                   string                 `yaml:"pid-file,omitempty"`
+	LogFile                   string                 `yaml:"log-file,omitempty"`
+	Services                  string                 `yaml:"services,omitempty"`
+	Ec2MetadataAccess         bool                   `yaml:"ec2-metadata-access,omitempty"`
+	NotificationSocket        string                 `yaml:"notification,omitempty"`
+	GatewayExposeAllProtocols bool                   `yaml:"gateway-expose-all-protocols,omitempty"`
 }
 
 type GvproxyConfigForward struct {
@@ -139,6 +141,8 @@ func GvproxyArgParse(flagSet *flag.FlagSet, args *GvproxyArgs, argv []string) (*
 	flagSet.StringVar(&args.servicesEndpoint, "services", "", "Exposes the same HTTP API as the --listen flag, without the /connect endpoint")
 	flagSet.BoolVar(&args.ec2MetadataAccess, "ec2-metadata-access", false, "Permits access to EC2 Metadata Service and Amazon Time Sync Service")
 	flagSet.StringVar(&args.notificationSocket, "notification", "", "Socket to be used to send network-ready notifications")
+	flagSet.BoolVar(&args.gatewayExposeAllProtocols, "gateway-expose-all-protocols", false, "Allow all protocols (including unix/npipe) on the gateway /expose API. By default only tcp and udp are allowed")
+
 	if err := flagSet.Parse(argv); err != nil {
 		return nil, err
 	}
@@ -303,6 +307,9 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 	}
 	if args.ec2MetadataAccess {
 		config.Ec2MetadataAccess = true
+	}
+	if args.gatewayExposeAllProtocols {
+		config.GatewayExposeAllProtocols = true
 	}
 	if args.mtu != 0 {
 		config.Stack.MTU = args.mtu

--- a/cmd/gvproxy/config_test.go
+++ b/cmd/gvproxy/config_test.go
@@ -697,5 +697,61 @@ interfaces:
     stdio: accept
 `,
 		},
+		{
+			CaseName: "Legacy: gateway-expose-all-protocols flag",
+			Args:     []string{"-gateway-expose-all-protocols"},
+			ResultConfig: `log-level: info
+stack:
+    mtu: 1500
+    subnet: 192.168.127.0/24
+    gatewayIP: 192.168.127.1
+    deviceIP: 192.168.127.2
+    hostIP: 192.168.127.254
+    gatewayMacAddress: 5a:94:ef:e4:0c:dd
+    dns:
+        - name: containers.internal.
+          records:
+            - name: gateway
+              ip: 192.168.127.1
+            - name: host
+              ip: 192.168.127.254
+        - name: docker.internal.
+          records:
+            - name: gateway
+              ip: 192.168.127.1
+            - name: host
+              ip: 192.168.127.254
+    forwards:
+        127.0.0.1:2222: 192.168.127.2:22
+    nat:
+        192.168.127.254: 127.0.0.1
+    gatewayVirtualIPs:
+        - 192.168.127.254
+    vpnKitUUIDMacAddresses:
+        c3d68012-0208-11ea-9fd7-f2189899ab08: 5a:94:ef:e4:0c:ee
+    dhcpStaticLeases:
+        192.168.127.2: 5a:94:ef:e4:0c:ee
+gateway-expose-all-protocols: true
+`,
+		},
+		{
+			CaseName:    "config: gateway-expose-all-protocols",
+			Args:        []string{"-config", "config.yaml"},
+			InputConfig: `gateway-expose-all-protocols: true`,
+			ResultConfig: `log-level: info
+stack:
+    mtu: 1500
+    subnet: 192.168.127.0/24
+    gatewayIP: 192.168.127.1
+    deviceIP: 192.168.127.2
+    hostIP: 192.168.127.254
+    gatewayMacAddress: 5a:94:ef:e4:0c:dd
+    nat:
+        192.168.127.254: 127.0.0.1
+    gatewayVirtualIPs:
+        - 192.168.127.254
+gateway-expose-all-protocols: true
+`,
+		},
 	}
 }

--- a/cmd/gvproxy/gateway_test.go
+++ b/cmd/gvproxy/gateway_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mockHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestGatewayExposeHandler(t *testing.T) {
+	t.Parallel()
+	handler := gatewayExposeHandler(mockHandler())
+
+	tests := []struct {
+		name           string
+		body           string
+		expectedStatus int
+	}{
+		{
+			name:           "blocks unix protocol",
+			body:           `{"local":"/tmp/test.sock","remote":"tcp://192.168.127.2:22","protocol":"unix"}`,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "blocks npipe protocol",
+			body:           `{"local":"//./pipe/test","remote":"tcp://192.168.127.2:22","protocol":"npipe"}`,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "allows tcp protocol",
+			body:           `{"local":":8080","remote":"192.168.127.2:80","protocol":"tcp"}`,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "allows udp protocol",
+			body:           `{"local":":5353","remote":"192.168.127.2:53","protocol":"udp"}`,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "rejects invalid json",
+			body:           `not json`,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "rejects empty body",
+			body:           ``,
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/services/forwarder/expose", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+		})
+	}
+}
+
+func TestGatewayExposeHandlerBlockMessage(t *testing.T) {
+	t.Parallel()
+	handler := gatewayExposeHandler(mockHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/services/forwarder/expose",
+		strings.NewReader(`{"local":"/tmp/test.sock","remote":"tcp://192.168.127.2:22","protocol":"unix"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "only tcp and udp protocols are allowed")
+}

--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -152,7 +155,7 @@ func run(ctx context.Context, g *errgroup.Group, config *GvproxyConfig) error {
 		log.Infof("enabling services API. Listening %s", config.Services)
 		ln, err := transport.Listen(config.Services)
 		if err != nil {
-			return fmt.Errorf("cannot listen: %w", err)
+			return fmt.Errorf("cannot listen: %w", err)
 		}
 		httpServe(ctx, g, ln, vn.ServicesMux())
 	}
@@ -163,7 +166,11 @@ func run(ctx context.Context, g *errgroup.Group, config *GvproxyConfig) error {
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/services/forwarder/all", vn.Mux())
-	mux.Handle("/services/forwarder/expose", vn.Mux())
+	if config.GatewayExposeAllProtocols {
+		mux.Handle("/services/forwarder/expose", vn.Mux())
+	} else {
+		mux.Handle("/services/forwarder/expose", gatewayExposeHandler(vn.Mux()))
+	}
 	mux.Handle("/services/forwarder/unexpose", vn.Mux())
 	httpServe(ctx, g, ln, mux)
 
@@ -385,6 +392,37 @@ func withProfiler(vn *virtualnetwork.VirtualNetwork) http.Handler {
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	}
 	return mux
+}
+
+func gatewayExposeHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Protocol string `json:"protocol"`
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		r.Body.Close()
+
+		if err := json.Unmarshal(bodyBytes, &req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// Empty protocol is allowed because the /expose handler defaults it to tcp
+		if req.Protocol != "tcp" && req.Protocol != "udp" && req.Protocol != "" {
+			log.Warnf("blocked %s protocol on gateway API", req.Protocol)
+			http.Error(w, "only tcp and udp protocols are allowed on the gateway API", http.StatusForbidden)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		next.ServeHTTP(w, r)
+	})
 }
 
 func searchDomains() []string {

--- a/pkg/services/forwarder/ports.go
+++ b/pkg/services/forwarder/ports.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"net/http"
 	"net/url"
@@ -161,9 +162,19 @@ func (f *PortsForwarder) Expose(protocol types.TransportProtocol, local, remote 
 		switch protocol {
 		case types.UNIX:
 			p.ListenFunc = func(_, socketPath string) (net.Listener, error) {
-				// remove existing socket file
-				if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+				info, err := os.Stat(socketPath)
+				if err != nil && !os.IsNotExist(err) {
+					// any error other than file does not exist is fatal
 					return nil, err
+				}
+				if err == nil {
+					if info.Mode().Type() != fs.ModeSocket {
+						return nil, fmt.Errorf("path already exists and is not a socket: %s", socketPath)
+					}
+					// remove existing socket file
+					if err := os.Remove(socketPath); err != nil {
+						return nil, err
+					}
 				}
 				return net.Listen("unix", socketPath) // override tcp to use unix socket
 			}

--- a/pkg/services/forwarder/ports.go
+++ b/pkg/services/forwarder/ports.go
@@ -162,7 +162,7 @@ func (f *PortsForwarder) Expose(protocol types.TransportProtocol, local, remote 
 		switch protocol {
 		case types.UNIX:
 			p.ListenFunc = func(_, socketPath string) (net.Listener, error) {
-				info, err := os.Stat(socketPath)
+				info, err := os.Lstat(socketPath)
 				if err != nil && !os.IsNotExist(err) {
 					// any error other than file does not exist is fatal
 					return nil, err

--- a/pkg/types/gvproxy_command.go
+++ b/pkg/types/gvproxy_command.go
@@ -33,6 +33,9 @@ type GvproxyCommand struct {
 
 	// SSHPort to access the guest VM
 	SSHPort int
+
+	// GatewayExposeAllProtocols allows all protocols on the gateway /expose API
+	GatewayExposeAllProtocols bool
 }
 
 func NewGvproxyCommand() GvproxyCommand {
@@ -210,6 +213,11 @@ func (c *GvproxyCommand) ToCmdline() []string {
 	// log-file
 	if c.LogFile != "" {
 		args = append(args, "-log-file", c.LogFile)
+	}
+
+	// gateway-expose-all-protocols
+	if c.GatewayExposeAllProtocols {
+		args = append(args, "-gateway-expose-all-protocols")
 	}
 
 	return args

--- a/test-qemu/suite_test.go
+++ b/test-qemu/suite_test.go
@@ -65,6 +65,7 @@ func gvproxyCmd() *exec.Cmd {
 	cmd := types.NewGvproxyCommand()
 	cmd.AddEndpoint(fmt.Sprintf("unix://%s", sock))
 	cmd.AddQemuSocket("tcp://" + net.JoinHostPort("127.0.0.1", strconv.Itoa(qemuPort)))
+	cmd.GatewayExposeAllProtocols = true
 	cmd.AddForwardSock(forwardSock)
 	cmd.AddForwardDest(podmanSock)
 	cmd.AddForwardUser(ignitionUser)


### PR DESCRIPTION
The unix socket ListenFunc now checks whether an existing path is
actually a socket (fs.ModeSocket) before removing it. Regular files,
directories, and other file types are rejected. This follows the
standard unix daemon pattern of cleaning up stale sockets while
preventing arbitrary file deletion.

In addition, a mechanism that blocks unix and npipe protocols on the gateway /expose endpoint has been added, to prevent containers from creating or manipulating host filesystem sockets via the VM-accessible API.

A new --gateway-expose-all-protocols flag re-enables the old behavior
for users who need unix/npipe forwarding from the gateway. By default,
only tcp and udp are allowed.