### PR TITLE
sockets: set gvproxy-created unix sockets to 0600

### DIFF
--- a/pkg/transport/listen.go
+++ b/pkg/transport/listen.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"net/url"
+	"os"
 	"runtime"
 )
 
@@ -23,7 +24,16 @@ func UnixSocketPath(u *url.URL, goos string) string {
 func defaultListenURL(url *url.URL) (net.Listener, error) {
 	switch url.Scheme {
 	case "unix":
-		return net.Listen(url.Scheme, UnixSocketPath(url, runtime.GOOS))
+		path := UnixSocketPath(url, runtime.GOOS)
+		listener, err := net.Listen(url.Scheme, path)
+		if err != nil {
+			return nil, err
+		}
+		if err := os.Chmod(path, 0600); err != nil {
+			_ = listener.Close()
+			return nil, err
+		}
+		return listener, nil
 	case "tcp":
 		return net.Listen("tcp", url.Host)
 	default:

--- a/pkg/transport/listen.go
+++ b/pkg/transport/listen.go
@@ -29,7 +29,7 @@ func defaultListenURL(url *url.URL) (net.Listener, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := os.Chmod(path, 0600); err != nil {
+		if err := os.Chmod(path, 0600); err != nil { // #nosec G703 - socket path from configured listen URL
 			_ = listener.Close()
 			return nil, err
 		}

--- a/pkg/transport/listen_darwin.go
+++ b/pkg/transport/listen_darwin.go
@@ -22,10 +22,18 @@ func listenURL(parsed *url.URL) (net.Listener, error) {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) { // #nosec G703 - constructed path for socket cleanup
 			return nil, err
 		}
-		return net.ListenUnix("unix", &net.UnixAddr{
+		listener, err := net.ListenUnix("unix", &net.UnixAddr{
 			Name: path,
 			Net:  "unix",
 		})
+		if err != nil {
+			return nil, err
+		}
+		if err := os.Chmod(path, 0600); err != nil {
+			_ = listener.Close()
+			return nil, err
+		}
+		return listener, nil
 	default:
 		return defaultListenURL(parsed)
 	}

--- a/pkg/transport/listen_darwin.go
+++ b/pkg/transport/listen_darwin.go
@@ -29,7 +29,7 @@ func listenURL(parsed *url.URL) (net.Listener, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := os.Chmod(path, 0600); err != nil {
+		if err := os.Chmod(path, 0600); err != nil { // #nosec G703 - constructed path for socket permissions
 			_ = listener.Close()
 			return nil, err
 		}

--- a/pkg/transport/listen_linux.go
+++ b/pkg/transport/listen_linux.go
@@ -33,7 +33,7 @@ func listenURL(parsed *url.URL) (net.Listener, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := os.Chmod(parsed.Path, 0600); err != nil {
+		if err := os.Chmod(parsed.Path, 0600); err != nil { // #nosec G703 - socket path from configured listen URL
 			_ = listener.Close()
 			return nil, err
 		}

--- a/pkg/transport/listen_linux.go
+++ b/pkg/transport/listen_linux.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"net"
 	"net/url"
+	"os"
 	"strconv"
 
 	mdlayhervsock "github.com/mdlayher/vsock"
@@ -28,7 +29,15 @@ func listenURL(parsed *url.URL) (net.Listener, error) {
 
 		return mdlayhervsock.Listen(uint32(port), nil)
 	case "unixpacket":
-		return net.Listen(parsed.Scheme, parsed.Path)
+		listener, err := net.Listen(parsed.Scheme, parsed.Path)
+		if err != nil {
+			return nil, err
+		}
+		if err := os.Chmod(parsed.Path, 0600); err != nil {
+			_ = listener.Close()
+			return nil, err
+		}
+		return listener, nil
 	default:
 		return defaultListenURL(parsed)
 	}

--- a/pkg/transport/unixgram_unix.go
+++ b/pkg/transport/unixgram_unix.go
@@ -105,7 +105,7 @@ func ListenUnixgram(endpoint string) (*net.UnixConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := os.Chmod(parsed.Path, 0600); err != nil {
+	if err := os.Chmod(parsed.Path, 0600); err != nil { // #nosec G703 - socket path from configured listen URL
 		_ = conn.Close()
 		return nil, err
 	}

--- a/pkg/transport/unixgram_unix.go
+++ b/pkg/transport/unixgram_unix.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"syscall"
 )
 
@@ -97,10 +98,18 @@ func ListenUnixgram(endpoint string) (*net.UnixConn, error) {
 	if parsed.Scheme != "unixgram" {
 		return nil, errors.New("unexpected scheme")
 	}
-	return net.ListenUnixgram("unixgram", &net.UnixAddr{
+	conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
 		Name: parsed.Path,
 		Net:  "unixgram",
 	})
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(parsed.Path, 0600); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
 }
 
 func AcceptVfkit(listeningConn *net.UnixConn) (net.Conn, error) {


### PR DESCRIPTION
These changes prevent a user from accessing a gvproxy process started by another user:

For example, before the changes, another user can expose/unexpose an endpoint:

```
% sudo -u crcattacker curl --unix-socket /tmp/gv-services.sock http:/unix/services/forwarder/expose -X POST \  
  -d '{"local":":19090","remote":"192.168.127.2:8080"}'
```
After the changes:
```
% sudo -u crcattacker curl --unix-socket /tmp/gv-services.sock http:/unix/services/forwarder/expose -X POST \
  -d '{"local":":19090","remote":"192.168.127.2:8080"}'

curl: (7) Failed to connect to unix port 80 after 0 ms: Couldn't connect to server
```