### PR TITLE
dns: add input validation to /add endpoint (RHDESK-553)

### DIFF
--- a/cmd/gvproxy/config.go
+++ b/cmd/gvproxy/config.go
@@ -386,7 +386,8 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 
 		config.Stack.DNS = []types.Zone{
 			{
-				Name: "containers.internal.",
+				Name:      "containers.internal.",
+				Protected: true,
 				Records: []types.Record{
 					{
 						Name: gateway,
@@ -399,7 +400,8 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 				},
 			},
 			{
-				Name: "docker.internal.",
+				Name:      "docker.internal.",
+				Protected: true,
 				Records: []types.Record{
 					{
 						Name: gateway,

--- a/cmd/gvproxy/config_test.go
+++ b/cmd/gvproxy/config_test.go
@@ -105,12 +105,14 @@ stack:
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     dns:
         - name: containers.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
             - name: host
               ip: 192.168.127.254
         - name: docker.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
@@ -138,12 +140,14 @@ stack:
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     dns:
         - name: containers.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
             - name: host
               ip: 192.168.127.254
         - name: docker.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
@@ -170,12 +174,14 @@ stack:
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     dns:
         - name: containers.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
             - name: host
               ip: 192.168.127.254
         - name: docker.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
@@ -209,12 +215,14 @@ stack:
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     dns:
         - name: containers.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
             - name: host
               ip: 192.168.127.254
         - name: docker.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
@@ -251,12 +259,14 @@ stack:
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     dns:
         - name: containers.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
             - name: host
               ip: 192.168.127.254
         - name: docker.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
@@ -293,12 +303,14 @@ stack:
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     dns:
         - name: containers.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
             - name: host
               ip: 192.168.127.254
         - name: docker.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
@@ -335,12 +347,14 @@ stack:
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     dns:
         - name: containers.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
             - name: host
               ip: 192.168.127.254
         - name: docker.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
@@ -377,12 +391,14 @@ stack:
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     dns:
         - name: containers.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
             - name: host
               ip: 192.168.127.254
         - name: docker.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
@@ -614,12 +630,14 @@ stack:
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     dns:
         - name: containers.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
             - name: host
               ip: 192.168.127.254
         - name: docker.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
@@ -651,12 +669,14 @@ stack:
     gatewayMacAddress: 5a:94:ef:e4:0c:dd
     dns:
         - name: containers.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1
             - name: host
               ip: 192.168.127.254
         - name: docker.internal.
+          protected: true
           records:
             - name: gateway
               ip: 192.168.127.1

--- a/pkg/services/dns/dns.go
+++ b/pkg/services/dns/dns.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -22,6 +23,8 @@ type upstreamResolver interface {
 	LookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error)
 	LookupTXT(ctx context.Context, name string) ([]string, error)
 }
+
+var validDNSChars = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 type dnsHandler struct {
 	zones     []types.Zone
@@ -58,13 +61,15 @@ func (h *dnsHandler) addLocalAnswers(m *dns.Msg, q dns.Question) bool {
 
 	for _, zone := range h.zones {
 		zoneSuffix := fmt.Sprintf(".%s", zone.Name)
-		if strings.HasSuffix(q.Name, zoneSuffix) {
+		lowerName := strings.ToLower(q.Name)
+		lowerSuffix := strings.ToLower(zoneSuffix)
+		if strings.HasSuffix(lowerName, lowerSuffix) {
 			if q.Qtype != dns.TypeA {
 				return false
 			}
 			for _, record := range zone.Records {
-				withoutZone := strings.TrimSuffix(q.Name, zoneSuffix)
-				if (record.Name != "" && record.Name == withoutZone) ||
+				withoutZone := strings.TrimSuffix(lowerName, lowerSuffix)
+				if (record.Name != "" && strings.EqualFold(record.Name, withoutZone)) ||
 					(record.Regexp != nil && record.Regexp.MatchString(withoutZone)) {
 					m.Answer = append(m.Answer, &dns.A{
 						Hdr: dns.RR_Header{
@@ -294,22 +299,81 @@ func (s *Server) Mux() http.Handler {
 			return
 		}
 
-		s.addZone(req)
+		if err := s.validateZone(req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if err := s.addZone(req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 	return mux
 }
 
-func (s *Server) addZone(req types.Zone) {
+func (s *Server) validateZone(req types.Zone) error {
+	if req.Name == "" {
+		return fmt.Errorf("zone name is required")
+	}
+
+	if req.Name == "." {
+		return fmt.Errorf("cannot add root zone")
+	}
+
+	if !dns.IsFqdn(req.Name) {
+		return fmt.Errorf("zone name must be fully qualified (end with '.'): %s", req.Name)
+	}
+
+	if _, ok := dns.IsDomainName(req.Name); !ok {
+		return fmt.Errorf("invalid DNS zone name: %s", req.Name)
+	}
+
+	if !isValidDNSName(req.Name) {
+		return fmt.Errorf("zone name contains invalid characters: %s", req.Name)
+	}
+
+	if len(req.Records) == 0 && (req.DefaultIP == nil || req.DefaultIP.IsUnspecified()) {
+		return fmt.Errorf("zone must have at least one record or a default IP")
+	}
+
+	for _, record := range req.Records {
+		if record.Name == "" {
+			return fmt.Errorf("record name is required")
+		}
+		if !isValidDNSName(record.Name) {
+			return fmt.Errorf("record name contains invalid characters: %s", record.Name)
+		}
+		if record.IP == nil && record.Regexp == nil {
+			return fmt.Errorf("record %s must have an IP or regexp", record.Name)
+		}
+	}
+
+	return nil
+}
+
+func isValidDNSName(name string) bool {
+	return validDNSChars.MatchString(name)
+}
+
+func (s *Server) addZone(req types.Zone) error {
 	s.handler.zonesLock.Lock()
 	defer s.handler.zonesLock.Unlock()
 	for i, zone := range s.handler.zones {
-		if zone.Name == req.Name {
+		if strings.EqualFold(zone.Name, req.Name) {
+			if zone.Protected {
+				return fmt.Errorf("cannot modify protected zone: %s", req.Name)
+			}
 			req.Records = append(req.Records, zone.Records...)
+			req.Protected = zone.Protected
+			req.Name = zone.Name
 			s.handler.zones[i] = req
-			return
+			return nil
 		}
 	}
 	// No existing zone for req.Name, add new one
+	req.Protected = false
 	s.handler.zones = append(s.handler.zones, req)
+	return nil
 }

--- a/pkg/services/dns/dns_test.go
+++ b/pkg/services/dns/dns_test.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"context"
 	"net"
+	"regexp"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 			Name:      "internal.",
 			DefaultIP: net.ParseIP("192.168.0.1"),
 		}
-		server.addZone(req)
+		gomega.Expect(server.addZone(req)).To(gomega.Succeed())
 
 		gomega.Expect(server.handler.zones).To(gomega.Equal([]types.Zone{req}))
 	})
@@ -45,7 +46,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 				IP:   net.ParseIP("192.168.0.2"),
 			}},
 		}
-		server.addZone(req)
+		gomega.Expect(server.addZone(req)).To(gomega.Succeed())
 
 		gomega.Expect(server.handler.zones).To(gomega.Equal([]types.Zone{req}))
 	})
@@ -62,8 +63,8 @@ var _ = ginkgo.Describe("dns add test", func() {
 				IP:   net.ParseIP("192.168.0.2"),
 			}},
 		}
-		server.addZone(ipReq)
-		server.addZone(recordReq)
+		gomega.Expect(server.addZone(ipReq)).To(gomega.Succeed())
+		gomega.Expect(server.addZone(recordReq)).To(gomega.Succeed())
 
 		gomega.Expect(server.handler.zones).To(gomega.Equal([]types.Zone{ipReq, recordReq}))
 	})
@@ -73,7 +74,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 			Name:      "internal.",
 			DefaultIP: net.ParseIP("192.168.0.1"),
 		}
-		server.addZone(ipReq)
+		gomega.Expect(server.addZone(ipReq)).To(gomega.Succeed())
 		recordReq := types.Zone{
 			Name: "internal.",
 			Records: []types.Record{{
@@ -81,7 +82,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 				IP:   net.ParseIP("192.168.0.2"),
 			}},
 		}
-		server.addZone(recordReq)
+		gomega.Expect(server.addZone(recordReq)).To(gomega.Succeed())
 
 		gomega.Expect(server.handler.zones).To(gomega.Equal([]types.Zone{{
 			Name: "internal.",
@@ -100,7 +101,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 				IP:   net.ParseIP("192.168.0.2"),
 			}},
 		}
-		server.addZone(ipReq)
+		gomega.Expect(server.addZone(ipReq)).To(gomega.Succeed())
 		recordReq := types.Zone{
 			Name: "internal.",
 			Records: []types.Record{{
@@ -108,7 +109,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 				IP:   net.ParseIP("192.168.0.3"),
 			}},
 		}
-		server.addZone(recordReq)
+		gomega.Expect(server.addZone(recordReq)).To(gomega.Succeed())
 
 		gomega.Expect(server.handler.zones).To(gomega.Equal([]types.Zone{{
 			Name: "internal.",
@@ -130,7 +131,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 				IP:   net.ParseIP("192.168.0.2"),
 			}},
 		}
-		server.addZone(ipReq)
+		gomega.Expect(server.addZone(ipReq)).To(gomega.Succeed())
 		recordReq := types.Zone{
 			Name: "internal.",
 			Records: []types.Record{{
@@ -138,7 +139,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 				IP:   net.ParseIP("192.168.0.3"),
 			}},
 		}
-		server.addZone(recordReq)
+		gomega.Expect(server.addZone(recordReq)).To(gomega.Succeed())
 
 		gomega.Expect(server.handler.zones).To(gomega.Equal([]types.Zone{{
 			Name: "internal.",
@@ -168,7 +169,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 				},
 			},
 		})
-		server.addZone(types.Zone{
+		gomega.Expect(server.addZone(types.Zone{
 			Name: "testing.",
 			Records: []types.Record{
 				{
@@ -176,7 +177,7 @@ var _ = ginkgo.Describe("dns add test", func() {
 					IP:   net.ParseIP("192.168.127.1"),
 				},
 			},
-		})
+		})).To(gomega.Succeed())
 		gomega.Expect(server.handler.zones).To(gomega.Equal([]types.Zone{
 			{
 				Name:      "crc.testing.",
@@ -222,6 +223,233 @@ var _ = ginkgo.Describe("dns add test", func() {
 		gomega.Expect(m.Answer[0].String()).To(gomega.SatisfyAny(gomega.ContainSubstring("34.235.198.240"), gomega.ContainSubstring("52.200.142.250")))
 	})
 
+	ginkgo.It("should match existing zones case-insensitively", func() {
+		gomega.Expect(server.addZone(types.Zone{
+			Name:      "internal.",
+			DefaultIP: net.ParseIP("192.168.0.1"),
+		})).To(gomega.Succeed())
+		gomega.Expect(server.addZone(types.Zone{
+			Name: "Internal.",
+			Records: []types.Record{{
+				Name: "api",
+				IP:   net.ParseIP("192.168.0.2"),
+			}},
+		})).To(gomega.Succeed())
+		gomega.Expect(server.handler.zones).To(gomega.HaveLen(1))
+		gomega.Expect(server.handler.zones[0].Name).To(gomega.Equal("internal."))
+	})
+
+	ginkgo.It("should preserve Protected flag when merging into existing zone", func() {
+		server, _ = New(nil, nil, []types.Zone{
+			{Name: "system.internal.", Protected: true, DefaultIP: net.ParseIP("10.0.0.1")},
+		})
+		err := server.addZone(types.Zone{
+			Name:    "system.internal.",
+			Records: []types.Record{{Name: "api", IP: net.ParseIP("10.0.0.2")}},
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("protected zone"))
+	})
+
+	ginkgo.It("should set Protected to false for newly added zones", func() {
+		gomega.Expect(server.addZone(types.Zone{
+			Name:      "sneaky.zone.",
+			Protected: true,
+			DefaultIP: net.ParseIP("10.0.0.1"),
+		})).To(gomega.Succeed())
+		gomega.Expect(server.handler.zones[0].Protected).To(gomega.BeFalse())
+	})
+
+})
+
+var _ = ginkgo.Describe("dns zone validation", func() {
+	var server *Server
+
+	ginkgo.BeforeEach(func() {
+		server, _ = New(nil, nil, []types.Zone{
+			{
+				Name:      "containers.internal.",
+				Protected: true,
+				DefaultIP: net.ParseIP("192.168.127.1"),
+			},
+			{
+				Name:      "docker.internal.",
+				Protected: true,
+				DefaultIP: net.ParseIP("192.168.127.1"),
+			},
+		})
+	})
+
+	ginkgo.It("should reject empty zone name", func() {
+		err := server.validateZone(types.Zone{Name: ""})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("zone name is required"))
+	})
+
+	ginkgo.It("should reject zone name without trailing dot", func() {
+		err := server.validateZone(types.Zone{Name: "example.com"})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("fully qualified"))
+	})
+
+	ginkgo.It("should reject zone name with invalid characters", func() {
+		err := server.validateZone(types.Zone{Name: "my zone!.local."})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("invalid characters"))
+	})
+
+	ginkgo.It("should reject zone name with path traversal characters", func() {
+		err := server.validateZone(types.Zone{Name: "../etc/passwd."})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("invalid DNS zone name"))
+	})
+
+	ginkgo.It("should reject root zone", func() {
+		err := server.validateZone(types.Zone{
+			Name:      ".",
+			DefaultIP: net.ParseIP("1.2.3.4"),
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("root zone"))
+	})
+
+	ginkgo.It("should reject overwriting protected zone containers.internal.", func() {
+		err := server.addZone(types.Zone{
+			Name:      "containers.internal.",
+			DefaultIP: net.ParseIP("1.2.3.4"),
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("protected zone"))
+	})
+
+	ginkgo.It("should reject overwriting protected zone docker.internal.", func() {
+		err := server.addZone(types.Zone{
+			Name:      "docker.internal.",
+			DefaultIP: net.ParseIP("1.2.3.4"),
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("protected zone"))
+	})
+
+	ginkgo.It("should reject protected zone case-insensitively", func() {
+		err := server.addZone(types.Zone{
+			Name:      "Docker.Internal.",
+			DefaultIP: net.ParseIP("1.2.3.4"),
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("protected zone"))
+	})
+
+	ginkgo.It("should reject zone with no records and no default IP", func() {
+		err := server.validateZone(types.Zone{Name: "blackhole.local."})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("at least one record or a default IP"))
+	})
+
+	ginkgo.It("should reject zone with unspecified default IP and no records", func() {
+		err := server.validateZone(types.Zone{
+			Name:      "test.local.",
+			DefaultIP: net.ParseIP("0.0.0.0"),
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("at least one record or a default IP"))
+	})
+
+	ginkgo.It("should reject record name with invalid characters", func() {
+		err := server.validateZone(types.Zone{
+			Name: "myapp.local.",
+			Records: []types.Record{
+				{Name: "../../etc/passwd", IP: net.ParseIP("10.0.0.1")},
+			},
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("invalid characters"))
+	})
+
+	ginkgo.It("should accept record name with underscores", func() {
+		err := server.validateZone(types.Zone{
+			Name: "myapp.local.",
+			Records: []types.Record{
+				{Name: "_sip._tcp", IP: net.ParseIP("10.0.0.1")},
+			},
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should reject record with empty name", func() {
+		err := server.validateZone(types.Zone{
+			Name: "myapp.local.",
+			Records: []types.Record{
+				{Name: "", IP: net.ParseIP("10.0.0.1")},
+			},
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("record name is required"))
+	})
+
+	ginkgo.It("should reject record without IP or regexp", func() {
+		err := server.validateZone(types.Zone{
+			Name: "myapp.local.",
+			Records: []types.Record{
+				{Name: "api"},
+			},
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("must have an IP or regexp"))
+	})
+
+	ginkgo.It("should accept valid custom zone", func() {
+		err := server.validateZone(types.Zone{
+			Name:      "myapp.local.",
+			DefaultIP: net.ParseIP("10.0.0.1"),
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should accept valid zone with records", func() {
+		err := server.validateZone(types.Zone{
+			Name: "myapp.local.",
+			Records: []types.Record{
+				{Name: "api", IP: net.ParseIP("10.0.0.1")},
+				{Name: "web", IP: net.ParseIP("10.0.0.2")},
+			},
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should accept zone with no records and only default IP", func() {
+		err := server.validateZone(types.Zone{
+			Name:      "wildcard.local.",
+			DefaultIP: net.ParseIP("10.0.0.1"),
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should accept record with regexp and no IP", func() {
+		err := server.validateZone(types.Zone{
+			Name: "myapp.local.",
+			Records: []types.Record{
+				{Name: "wildcard", Regexp: regexp.MustCompile(".*")},
+			},
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should accept zone name with hyphens", func() {
+		err := server.validateZone(types.Zone{
+			Name:      "my-app.local.",
+			DefaultIP: net.ParseIP("10.0.0.1"),
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should not protect zones that were not in the initial configuration", func() {
+		err := server.validateZone(types.Zone{
+			Name:      "custom.zone.",
+			DefaultIP: net.ParseIP("10.0.0.1"),
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
 })
 
 var _ = ginkgo.Describe("TXT records", func() {

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -80,6 +80,10 @@ type Zone struct {
 	Name      string   `yaml:"name,omitempty"`
 	Records   []Record `yaml:"records,omitempty"`
 	DefaultIP net.IP   `yaml:"defaultIP,omitempty"`
+	// Protected zones cannot be modified or overwritten via the API.
+	// Set this in the YAML configuration or in code to prevent a zone
+	// from being changed at runtime.
+	Protected bool `yaml:"protected,omitempty"`
 }
 
 type Record struct {


### PR DESCRIPTION
Add validation to the DNS /add API endpoint to prevent zone injection and overwriting of built-in zones. Previously, the endpoint accepted arbitrary DNS zones without any input validation.

The validateZone function checks:
- Zone name is non-empty, fully qualified, and contains valid DNS chars
- Root zone "." cannot be added (prevents catch-all hijacking)
- Built-in zones marked as Protected cannot be modified via the API
- Zones must have at least one record or a default IP (prevents DNS black holes)
- Record names are validated for valid DNS characters
- Records must have an IP or regexp

The addZone function now uses case-insensitive zone matching, preserves the Protected flag from existing zones on merge, and forces Protected=false for new zones added via the API.

A Protected field is added to the Zone type, set to true for the built-in containers.internal. and docker.internal. zones.