### PR TITLE
Fix notification socket path handling on Windows

### DIFF
--- a/cmd/gvproxy/config.go
+++ b/cmd/gvproxy/config.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/transport"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v3"
@@ -292,7 +293,7 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 		if uri.Scheme != "unix" {
 			return config, errors.New("notification listen address must be unix:// address")
 		}
-		config.NotificationSocket = uri.Path
+		config.NotificationSocket = transport.UnixSocketPath(uri, runtime.GOOS)
 	}
 	if len(args.endpoints) > 0 {
 		config.Listen = args.endpoints

--- a/pkg/sshclient/ssh_forwarder.go
+++ b/pkg/sshclient/ssh_forwarder.go
@@ -8,11 +8,11 @@ import (
 	"net/url"
 	"os"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/fs"
+	"github.com/containers/gvisor-tap-vsock/pkg/transport"
 	"github.com/containers/gvisor-tap-vsock/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
@@ -111,10 +111,7 @@ func connectForward(ctx context.Context, bastion *Bastion) (CloseWriteConn, erro
 }
 
 func listenUnix(socketURI *url.URL) (net.Listener, error) {
-	path := socketURI.Path
-	if runtime.GOOS == "windows" {
-		path = strings.TrimPrefix(path, "/")
-	}
+	path := transport.UnixSocketPath(socketURI, runtime.GOOS)
 
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) { // #nosec G703 - validated URL path for socket cleanup
 		return nil, err

--- a/pkg/transport/listen.go
+++ b/pkg/transport/listen.go
@@ -5,17 +5,25 @@ import (
 	"net"
 	"net/url"
 	"runtime"
-	"strings"
 )
+
+// UnixSocketPath extracts the filesystem path from a parsed unix:// URL,
+// handling the leading "/" that url.Parse adds before Windows drive letters
+// (e.g. unix:///c:/path → Path="/c:/path" -> "c:/path").
+// The goos parameter allows callers to specify the target OS for testability;
+// pass runtime.GOOS for production use.
+func UnixSocketPath(u *url.URL, goos string) string {
+	path := u.Path
+	if goos == "windows" && len(path) > 2 && path[0] == '/' && path[2] == ':' {
+		path = path[1:]
+	}
+	return path
+}
 
 func defaultListenURL(url *url.URL) (net.Listener, error) {
 	switch url.Scheme {
 	case "unix":
-		path := url.Path
-		if runtime.GOOS == "windows" {
-			path = strings.TrimPrefix(path, "/")
-		}
-		return net.Listen(url.Scheme, path)
+		return net.Listen(url.Scheme, UnixSocketPath(url, runtime.GOOS))
 	case "tcp":
 		return net.Listen("tcp", url.Host)
 	default:

--- a/pkg/transport/listen_test.go
+++ b/pkg/transport/listen_test.go
@@ -1,0 +1,64 @@
+package transport
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnixSocketPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		rawURL   string
+		goos     string
+		wantPath string
+	}{
+		{
+			name:     "Unix absolute path on linux",
+			rawURL:   "unix:///tmp/notification.sock",
+			goos:     "linux",
+			wantPath: "/tmp/notification.sock",
+		},
+		{
+			name:     "Unix absolute path on darwin",
+			rawURL:   "unix:///var/run/gvproxy.sock",
+			goos:     "darwin",
+			wantPath: "/var/run/gvproxy.sock",
+		},
+		{
+			name:     "Unix absolute path on windows is unchanged",
+			rawURL:   "unix:///tmp/notification.sock",
+			goos:     "windows",
+			wantPath: "/tmp/notification.sock",
+		},
+		{
+			name:     "Windows drive letter (three slashes)",
+			rawURL:   "unix:///c:/Users/foo/notification.sock",
+			goos:     "windows",
+			wantPath: "c:/Users/foo/notification.sock",
+		},
+		{
+			name:     "Windows drive letter nested path",
+			rawURL:   "unix:///d:/ProgramData/gvproxy/default.sock",
+			goos:     "windows",
+			wantPath: "d:/ProgramData/gvproxy/default.sock",
+		},
+		{
+			name:     "Windows drive letter not trimmed on linux",
+			rawURL:   "unix:///c:/Users/foo/notification.sock",
+			goos:     "linux",
+			wantPath: "/c:/Users/foo/notification.sock",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := url.Parse(tc.rawURL)
+			require.NoError(t, err)
+			got := UnixSocketPath(u, tc.goos)
+			assert.Equal(t, tc.wantPath, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes notification socket path handling on Windows and extracts this to a shared helper.