### PR TITLE
draft: api refactor

### DIFF
--- a/cmd/gvproxy/config.go
+++ b/cmd/gvproxy/config.go
@@ -23,30 +23,31 @@ const (
 )
 
 type GvproxyArgs struct {
-	config             string
-	endpoints          arrayFlags
-	debug              bool
-	mtu                int
-	sshPort            int
-	subnet             string
-	gatewayIP          string
-	deviceIP           string
-	hostIP             string
-	vpnkitSocket       string
-	qemuSocket         string
-	bessSocket         string
-	stdioSocket        string
-	vfkitSocket        string
-	notificationSocket string
-	forwardSocket      arrayFlags
-	forwardDest        arrayFlags
-	forwardUser        arrayFlags
-	forwardIdentify    arrayFlags
-	pidFile            string
-	pcapFile           string
-	logFile            string
-	servicesEndpoint   string
-	ec2MetadataAccess  bool
+	config                    string
+	endpoints                 arrayFlags
+	debug                     bool
+	mtu                       int
+	sshPort                   int
+	subnet                    string
+	gatewayIP                 string
+	deviceIP                  string
+	hostIP                    string
+	vpnkitSocket              string
+	qemuSocket                string
+	bessSocket                string
+	stdioSocket               string
+	vfkitSocket               string
+	notificationSocket        string
+	forwardSocket             arrayFlags
+	forwardDest               arrayFlags
+	forwardUser               arrayFlags
+	forwardIdentify           arrayFlags
+	pidFile                   string
+	pcapFile                  string
+	logFile                   string
+	servicesEndpoint          string
+	ec2MetadataAccess         bool
+	gatewayExposeAllProtocols bool
 }
 
 type GvproxyConfig struct {
@@ -60,12 +61,13 @@ type GvproxyConfig struct {
 		Stdio  string `yaml:"stdio,omitempty"`
 		Vfkit  string `yaml:"vfkit,omitempty"`
 	} `yaml:"interfaces,omitempty"`
-	Forwards           []GvproxyConfigForward `yaml:"forwards,omitempty"`
-	PIDFile            string                 `yaml:"pid-file,omitempty"`
-	LogFile            string                 `yaml:"log-file,omitempty"`
-	Services           string                 `yaml:"services,omitempty"`
-	Ec2MetadataAccess  bool                   `yaml:"ec2-metadata-access,omitempty"`
-	NotificationSocket string                 `yaml:"notification,omitempty"`
+	Forwards                  []GvproxyConfigForward `yaml:"forwards,omitempty"`
+	PIDFile                   string                 `yaml:"pid-file,omitempty"`
+	LogFile                   string                 `yaml:"log-file,omitempty"`
+	Services                  string                 `yaml:"services,omitempty"`
+	Ec2MetadataAccess         bool                   `yaml:"ec2-metadata-access,omitempty"`
+	NotificationSocket        string                 `yaml:"notification,omitempty"`
+	GatewayExposeAllProtocols bool                   `yaml:"gateway-expose-all-protocols,omitempty"`
 }
 
 type GvproxyConfigForward struct {
@@ -138,6 +140,8 @@ func GvproxyArgParse(flagSet *flag.FlagSet, args *GvproxyArgs, argv []string) (*
 	flagSet.StringVar(&args.servicesEndpoint, "services", "", "Exposes the same HTTP API as the --listen flag, without the /connect endpoint")
 	flagSet.BoolVar(&args.ec2MetadataAccess, "ec2-metadata-access", false, "Permits access to EC2 Metadata Service and Amazon Time Sync Service")
 	flagSet.StringVar(&args.notificationSocket, "notification", "", "Socket to be used to send network-ready notifications")
+	flagSet.BoolVar(&args.gatewayExposeAllProtocols, "gateway-expose-all-protocols", false, "Allow all protocols (including unix/npipe) on the gateway /expose API. By default only tcp and udp are allowed")
+
 	if err := flagSet.Parse(argv); err != nil {
 		return nil, err
 	}
@@ -302,6 +306,9 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 	}
 	if args.ec2MetadataAccess {
 		config.Ec2MetadataAccess = true
+	}
+	if args.gatewayExposeAllProtocols {
+		config.GatewayExposeAllProtocols = true
 	}
 	if args.mtu != 0 {
 		config.Stack.MTU = args.mtu

--- a/cmd/gvproxy/config.go
+++ b/cmd/gvproxy/config.go
@@ -24,30 +24,31 @@ const (
 )
 
 type GvproxyArgs struct {
-	config             string
-	endpoints          arrayFlags
-	debug              bool
-	mtu                int
-	sshPort            int
-	subnet             string
-	gatewayIP          string
-	deviceIP           string
-	hostIP             string
-	vpnkitSocket       string
-	qemuSocket         string
-	bessSocket         string
-	stdioSocket        string
-	vfkitSocket        string
-	notificationSocket string
-	forwardSocket      arrayFlags
-	forwardDest        arrayFlags
-	forwardUser        arrayFlags
-	forwardIdentify    arrayFlags
-	pidFile            string
-	pcapFile           string
-	logFile            string
-	servicesEndpoint   string
-	ec2MetadataAccess  bool
+	config                    string
+	endpoints                 arrayFlags
+	debug                     bool
+	mtu                       int
+	sshPort                   int
+	subnet                    string
+	gatewayIP                 string
+	deviceIP                  string
+	hostIP                    string
+	vpnkitSocket              string
+	qemuSocket                string
+	bessSocket                string
+	stdioSocket               string
+	vfkitSocket               string
+	notificationSocket        string
+	forwardSocket             arrayFlags
+	forwardDest               arrayFlags
+	forwardUser               arrayFlags
+	forwardIdentify           arrayFlags
+	pidFile                   string
+	pcapFile                  string
+	logFile                   string
+	servicesEndpoint          string
+	ec2MetadataAccess         bool
+	gatewayExposeAllProtocols bool
 }
 
 type GvproxyConfig struct {
@@ -61,12 +62,13 @@ type GvproxyConfig struct {
 		Stdio  string `yaml:"stdio,omitempty"`
 		Vfkit  string `yaml:"vfkit,omitempty"`
 	} `yaml:"interfaces,omitempty"`
-	Forwards           []GvproxyConfigForward `yaml:"forwards,omitempty"`
-	PIDFile            string                 `yaml:"pid-file,omitempty"`
-	LogFile            string                 `yaml:"log-file,omitempty"`
-	Services           string                 `yaml:"services,omitempty"`
-	Ec2MetadataAccess  bool                   `yaml:"ec2-metadata-access,omitempty"`
-	NotificationSocket string                 `yaml:"notification,omitempty"`
+	Forwards                  []GvproxyConfigForward `yaml:"forwards,omitempty"`
+	PIDFile                   string                 `yaml:"pid-file,omitempty"`
+	LogFile                   string                 `yaml:"log-file,omitempty"`
+	Services                  string                 `yaml:"services,omitempty"`
+	Ec2MetadataAccess         bool                   `yaml:"ec2-metadata-access,omitempty"`
+	NotificationSocket        string                 `yaml:"notification,omitempty"`
+	GatewayExposeAllProtocols bool                   `yaml:"gateway-expose-all-protocols,omitempty"`
 }
 
 type GvproxyConfigForward struct {
@@ -139,6 +141,8 @@ func GvproxyArgParse(flagSet *flag.FlagSet, args *GvproxyArgs, argv []string) (*
 	flagSet.StringVar(&args.servicesEndpoint, "services", "", "Exposes the same HTTP API as the --listen flag, without the /connect endpoint")
 	flagSet.BoolVar(&args.ec2MetadataAccess, "ec2-metadata-access", false, "Permits access to EC2 Metadata Service and Amazon Time Sync Service")
 	flagSet.StringVar(&args.notificationSocket, "notification", "", "Socket to be used to send network-ready notifications")
+	flagSet.BoolVar(&args.gatewayExposeAllProtocols, "gateway-expose-all-protocols", false, "Allow all protocols (including unix/npipe) on the gateway /expose API. By default only tcp and udp are allowed")
+
 	if err := flagSet.Parse(argv); err != nil {
 		return nil, err
 	}
@@ -303,6 +307,9 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 	}
 	if args.ec2MetadataAccess {
 		config.Ec2MetadataAccess = true
+	}
+	if args.gatewayExposeAllProtocols {
+		config.GatewayExposeAllProtocols = true
 	}
 	if args.mtu != 0 {
 		config.Stack.MTU = args.mtu

--- a/cmd/gvproxy/config_test.go
+++ b/cmd/gvproxy/config_test.go
@@ -697,5 +697,61 @@ interfaces:
     stdio: accept
 `,
 		},
+		{
+			CaseName: "Legacy: gateway-expose-all-protocols flag",
+			Args:     []string{"-gateway-expose-all-protocols"},
+			ResultConfig: `log-level: info
+stack:
+    mtu: 1500
+    subnet: 192.168.127.0/24
+    gatewayIP: 192.168.127.1
+    deviceIP: 192.168.127.2
+    hostIP: 192.168.127.254
+    gatewayMacAddress: 5a:94:ef:e4:0c:dd
+    dns:
+        - name: containers.internal.
+          records:
+            - name: gateway
+              ip: 192.168.127.1
+            - name: host
+              ip: 192.168.127.254
+        - name: docker.internal.
+          records:
+            - name: gateway
+              ip: 192.168.127.1
+            - name: host
+              ip: 192.168.127.254
+    forwards:
+        127.0.0.1:2222: 192.168.127.2:22
+    nat:
+        192.168.127.254: 127.0.0.1
+    gatewayVirtualIPs:
+        - 192.168.127.254
+    vpnKitUUIDMacAddresses:
+        c3d68012-0208-11ea-9fd7-f2189899ab08: 5a:94:ef:e4:0c:ee
+    dhcpStaticLeases:
+        192.168.127.2: 5a:94:ef:e4:0c:ee
+gateway-expose-all-protocols: true
+`,
+		},
+		{
+			CaseName:    "config: gateway-expose-all-protocols",
+			Args:        []string{"-config", "config.yaml"},
+			InputConfig: `gateway-expose-all-protocols: true`,
+			ResultConfig: `log-level: info
+stack:
+    mtu: 1500
+    subnet: 192.168.127.0/24
+    gatewayIP: 192.168.127.1
+    deviceIP: 192.168.127.2
+    hostIP: 192.168.127.254
+    gatewayMacAddress: 5a:94:ef:e4:0c:dd
+    nat:
+        192.168.127.254: 127.0.0.1
+    gatewayVirtualIPs:
+        - 192.168.127.254
+gateway-expose-all-protocols: true
+`,
+		},
 	}
 }

--- a/cmd/gvproxy/gateway_test.go
+++ b/cmd/gvproxy/gateway_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mockHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestGatewayExposeHandler(t *testing.T) {
+	t.Parallel()
+	handler := gatewayExposeHandler(mockHandler())
+
+	tests := []struct {
+		name           string
+		body           string
+		expectedStatus int
+	}{
+		{
+			name:           "blocks unix protocol",
+			body:           `{"local":"/tmp/test.sock","remote":"tcp://192.168.127.2:22","protocol":"unix"}`,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "blocks npipe protocol",
+			body:           `{"local":"//./pipe/test","remote":"tcp://192.168.127.2:22","protocol":"npipe"}`,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "allows tcp protocol",
+			body:           `{"local":":8080","remote":"192.168.127.2:80","protocol":"tcp"}`,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "allows udp protocol",
+			body:           `{"local":":5353","remote":"192.168.127.2:53","protocol":"udp"}`,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "rejects invalid json",
+			body:           `not json`,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "rejects empty body",
+			body:           ``,
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/services/forwarder/expose", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+		})
+	}
+}
+
+func TestGatewayExposeHandlerBlockMessage(t *testing.T) {
+	t.Parallel()
+	handler := gatewayExposeHandler(mockHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/services/forwarder/expose",
+		strings.NewReader(`{"local":"/tmp/test.sock","remote":"tcp://192.168.127.2:22","protocol":"unix"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "unix and npipe protocols are not allowed")
+}

--- a/cmd/gvproxy/gateway_test.go
+++ b/cmd/gvproxy/gateway_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/virtualnetwork"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +18,7 @@ func mockHandler() http.Handler {
 
 func TestGatewayExposeHandler(t *testing.T) {
 	t.Parallel()
-	handler := gatewayExposeHandler(mockHandler())
+	handler := virtualnetwork.GatewayProtocolFilter(mockHandler())
 
 	tests := []struct {
 		name           string
@@ -71,7 +72,7 @@ func TestGatewayExposeHandler(t *testing.T) {
 
 func TestGatewayExposeHandlerBlockMessage(t *testing.T) {
 	t.Parallel()
-	handler := gatewayExposeHandler(mockHandler())
+	handler := virtualnetwork.GatewayProtocolFilter(mockHandler())
 
 	req := httptest.NewRequest(http.MethodPost, "/services/forwarder/expose",
 		strings.NewReader(`{"local":"/tmp/test.sock","remote":"tcp://192.168.127.2:22","protocol":"unix"}`))

--- a/cmd/gvproxy/gateway_test.go
+++ b/cmd/gvproxy/gateway_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mockHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestGatewayExposeHandler(t *testing.T) {
+	t.Parallel()
+	handler := gatewayExposeHandler(mockHandler())
+
+	tests := []struct {
+		name           string
+		body           string
+		expectedStatus int
+	}{
+		{
+			name:           "blocks unix protocol",
+			body:           `{"local":"/tmp/test.sock","remote":"tcp://192.168.127.2:22","protocol":"unix"}`,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "blocks npipe protocol",
+			body:           `{"local":"//./pipe/test","remote":"tcp://192.168.127.2:22","protocol":"npipe"}`,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "allows tcp protocol",
+			body:           `{"local":":8080","remote":"192.168.127.2:80","protocol":"tcp"}`,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "allows udp protocol",
+			body:           `{"local":":5353","remote":"192.168.127.2:53","protocol":"udp"}`,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "rejects invalid json",
+			body:           `not json`,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "rejects empty body",
+			body:           ``,
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/services/forwarder/expose", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+		})
+	}
+}
+
+func TestGatewayExposeHandlerBlockMessage(t *testing.T) {
+	t.Parallel()
+	handler := gatewayExposeHandler(mockHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/services/forwarder/expose",
+		strings.NewReader(`{"local":"/tmp/test.sock","remote":"tcp://192.168.127.2:22","protocol":"unix"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "only tcp and udp protocols are allowed")
+}

--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -164,15 +161,7 @@ func run(ctx context.Context, g *errgroup.Group, config *GvproxyConfig) error {
 	if err != nil {
 		return err
 	}
-	mux := http.NewServeMux()
-	mux.Handle("/services/forwarder/all", vn.Mux())
-	if config.GatewayExposeAllProtocols {
-		mux.Handle("/services/forwarder/expose", vn.Mux())
-	} else {
-		mux.Handle("/services/forwarder/expose", gatewayExposeHandler(vn.Mux()))
-	}
-	mux.Handle("/services/forwarder/unexpose", vn.Mux())
-	httpServe(ctx, g, ln, mux)
+	httpServe(ctx, g, ln, vn.GatewayMux(config.GatewayExposeAllProtocols))
 
 	if InDebugMode() {
 		g.Go(func() error {
@@ -392,35 +381,6 @@ func withProfiler(vn *virtualnetwork.VirtualNetwork) http.Handler {
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	}
 	return mux
-}
-
-func gatewayExposeHandler(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req struct {
-			Protocol string `json:"protocol"`
-		}
-
-		bodyBytes, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		r.Body.Close()
-
-		if err := json.Unmarshal(bodyBytes, &req); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		if req.Protocol == "unix" || req.Protocol == "npipe" {
-			log.Warnf("blocked %s protocol on gateway API", req.Protocol)
-			http.Error(w, "unix and npipe protocols are not allowed on the gateway API", http.StatusForbidden)
-			return
-		}
-
-		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-		next.ServeHTTP(w, r)
-	})
 }
 
 func searchDomains() []string {

--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -152,7 +155,7 @@ func run(ctx context.Context, g *errgroup.Group, config *GvproxyConfig) error {
 		log.Infof("enabling services API. Listening %s", config.Services)
 		ln, err := transport.Listen(config.Services)
 		if err != nil {
-			return fmt.Errorf("cannot listen: %w", err)
+			return fmt.Errorf("cannot listen: %w", err)
 		}
 		httpServe(ctx, g, ln, vn.ServicesMux())
 	}
@@ -163,7 +166,11 @@ func run(ctx context.Context, g *errgroup.Group, config *GvproxyConfig) error {
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/services/forwarder/all", vn.Mux())
-	mux.Handle("/services/forwarder/expose", vn.Mux())
+	if config.GatewayExposeAllProtocols {
+		mux.Handle("/services/forwarder/expose", vn.Mux())
+	} else {
+		mux.Handle("/services/forwarder/expose", gatewayExposeHandler(vn.Mux()))
+	}
 	mux.Handle("/services/forwarder/unexpose", vn.Mux())
 	httpServe(ctx, g, ln, mux)
 
@@ -385,6 +392,35 @@ func withProfiler(vn *virtualnetwork.VirtualNetwork) http.Handler {
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	}
 	return mux
+}
+
+func gatewayExposeHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Protocol string `json:"protocol"`
+		}
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		r.Body.Close()
+
+		if err := json.Unmarshal(bodyBytes, &req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if req.Protocol == "unix" || req.Protocol == "npipe" {
+			log.Warnf("blocked %s protocol on gateway API", req.Protocol)
+			http.Error(w, "unix and npipe protocols are not allowed on the gateway API", http.StatusForbidden)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		next.ServeHTTP(w, r)
+	})
 }
 
 func searchDomains() []string {

--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -152,7 +155,7 @@ func run(ctx context.Context, g *errgroup.Group, config *GvproxyConfig) error {
 		log.Infof("enabling services API. Listening %s", config.Services)
 		ln, err := transport.Listen(config.Services)
 		if err != nil {
-			return fmt.Errorf("cannot listen: %w", err)
+			return fmt.Errorf("cannot listen: %w", err)
 		}
 		httpServe(ctx, g, ln, vn.ServicesMux())
 	}
@@ -163,7 +166,11 @@ func run(ctx context.Context, g *errgroup.Group, config *GvproxyConfig) error {
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/services/forwarder/all", vn.Mux())
-	mux.Handle("/services/forwarder/expose", vn.Mux())
+	if config.GatewayExposeAllProtocols {
+		mux.Handle("/services/forwarder/expose", vn.Mux())
+	} else {
+		mux.Handle("/services/forwarder/expose", gatewayExposeHandler(vn.Mux()))
+	}
 	mux.Handle("/services/forwarder/unexpose", vn.Mux())
 	httpServe(ctx, g, ln, mux)
 
@@ -385,6 +392,37 @@ func withProfiler(vn *virtualnetwork.VirtualNetwork) http.Handler {
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	}
 	return mux
+}
+
+func gatewayExposeHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Protocol string `json:"protocol"`
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		r.Body.Close()
+
+		if err := json.Unmarshal(bodyBytes, &req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// Empty protocol is allowed because the /expose handler defaults it to tcp
+		if req.Protocol != "tcp" && req.Protocol != "udp" && req.Protocol != "" {
+			log.Warnf("blocked %s protocol on gateway API", req.Protocol)
+			http.Error(w, "only tcp and udp protocols are allowed on the gateway API", http.StatusForbidden)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		next.ServeHTTP(w, r)
+	})
 }
 
 func searchDomains() []string {

--- a/pkg/services/dhcp/dhcp.go
+++ b/pkg/services/dhcp/dhcp.go
@@ -1,11 +1,9 @@
 package dhcp
 
 import (
-	"encoding/json"
 	"errors"
 	"math"
 	"net"
-	"net/http"
 	"time"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/tap"
@@ -128,10 +126,6 @@ func (s *Server) Serve() error {
 	return s.Underlying.Serve()
 }
 
-func (s *Server) Mux() http.Handler {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/leases", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(s.IPPool.Leases())
-	})
-	return mux
+func (s *Server) Leases() map[string]string {
+	return s.IPPool.Leases()
 }

--- a/pkg/services/dns/dns.go
+++ b/pkg/services/dns/dns.go
@@ -2,10 +2,8 @@ package dns
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
-	"net/http"
 	"strings"
 	"sync"
 
@@ -275,29 +273,16 @@ func (s *Server) ServeTCP() error {
 	return tcpSrv.ActivateAndServe()
 }
 
-func (s *Server) Mux() http.Handler {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/all", func(w http.ResponseWriter, _ *http.Request) {
-		s.handler.zonesLock.RLock()
-		_ = json.NewEncoder(w).Encode(s.handler.zones)
-		s.handler.zonesLock.RUnlock()
-	})
+func (s *Server) Zones() []types.Zone {
+	s.handler.zonesLock.RLock()
+	defer s.handler.zonesLock.RUnlock()
+	zones := make([]types.Zone, len(s.handler.zones))
+	copy(zones, s.handler.zones)
+	return zones
+}
 
-	mux.HandleFunc("/add", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "post only", http.StatusBadRequest)
-			return
-		}
-		var req types.Zone
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		s.addZone(req)
-		w.WriteHeader(http.StatusOK)
-	})
-	return mux
+func (s *Server) AddZone(req types.Zone) {
+	s.addZone(req)
 }
 
 func (s *Server) addZone(req types.Zone) {

--- a/pkg/services/forwarder/ports.go
+++ b/pkg/services/forwarder/ports.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"net/http"
 	"net/url"
@@ -161,9 +162,19 @@ func (f *PortsForwarder) Expose(protocol types.TransportProtocol, local, remote 
 		switch protocol {
 		case types.UNIX:
 			p.ListenFunc = func(_, socketPath string) (net.Listener, error) {
-				// remove existing socket file
-				if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+				info, err := os.Stat(socketPath)
+				if err != nil && !os.IsNotExist(err) {
+					// any error other than file does not exist is fatal
 					return nil, err
+				}
+				if err == nil {
+					if info.Mode().Type() != fs.ModeSocket {
+						return nil, fmt.Errorf("path already exists and is not a socket: %s", socketPath)
+					}
+					// remove existing socket file
+					if err := os.Remove(socketPath); err != nil {
+						return nil, err
+					}
 				}
 				return net.Listen("unix", socketPath) // override tcp to use unix socket
 			}

--- a/pkg/services/forwarder/ports.go
+++ b/pkg/services/forwarder/ports.go
@@ -2,13 +2,11 @@ package forwarder
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"sort"
@@ -32,10 +30,10 @@ type PortsForwarder struct {
 	stack *stack.Stack
 
 	proxiesLock sync.Mutex
-	proxies     map[ProxyKey]proxy
+	proxies     map[ProxyKey]Proxy
 }
 
-type proxy struct {
+type Proxy struct {
 	Local      string `json:"local"`
 	Remote     string `json:"remote"`
 	Protocol   string `json:"protocol"`
@@ -64,7 +62,7 @@ func (w CloseWrapper) Close() error {
 func NewPortsForwarder(s *stack.Stack) *PortsForwarder {
 	return &PortsForwarder{
 		stack:   s,
-		proxies: make(map[ProxyKey]proxy),
+		proxies: make(map[ProxyKey]Proxy),
 	}
 }
 
@@ -199,7 +197,7 @@ func (f *PortsForwarder) Expose(protocol types.TransportProtocol, local, remote 
 				log.Error(err)
 			}
 		}()
-		f.proxies[key(protocol, local)] = proxy{
+		f.proxies[key(protocol, local)] = Proxy{
 			Protocol: string(protocol),
 			Local:    local,
 			Remote:   remote,
@@ -231,7 +229,7 @@ func (f *PortsForwarder) Expose(protocol types.TransportProtocol, local, remote 
 			return err
 		}
 		go p.Run()
-		f.proxies[key(protocol, local)] = proxy{
+		f.proxies[key(protocol, local)] = Proxy{
 			Protocol:   "udp",
 			Local:      local,
 			Remote:     remote,
@@ -258,7 +256,7 @@ func (f *PortsForwarder) Expose(protocol types.TransportProtocol, local, remote 
 				log.Error(err)
 			}
 		}()
-		f.proxies[key(protocol, local)] = proxy{
+		f.proxies[key(protocol, local)] = Proxy{
 			Protocol:   "tcp",
 			Local:      local,
 			Remote:     remote,
@@ -285,76 +283,24 @@ func (f *PortsForwarder) Unexpose(protocol types.TransportProtocol, local string
 	return proxy.underlying.Close()
 }
 
-func (f *PortsForwarder) Mux() http.Handler {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/all", func(w http.ResponseWriter, _ *http.Request) {
-		f.proxiesLock.Lock()
-		defer f.proxiesLock.Unlock()
-		ret := make([]proxy, 0)
-		for _, proxy := range f.proxies {
-			ret = append(ret, proxy)
+func (f *PortsForwarder) List() []Proxy {
+	f.proxiesLock.Lock()
+	defer f.proxiesLock.Unlock()
+	ret := make([]Proxy, 0)
+	for _, p := range f.proxies {
+		ret = append(ret, p)
+	}
+	sort.Slice(ret, func(i, j int) bool {
+		if ret[i].Local == ret[j].Local {
+			return ret[i].Protocol < ret[j].Protocol
 		}
-		sort.Slice(ret, func(i, j int) bool {
-			if ret[i].Local == ret[j].Local {
-				return ret[i].Protocol < ret[j].Protocol
-			}
-			return ret[i].Local < ret[j].Local
-		})
-		_ = json.NewEncoder(w).Encode(ret)
+		return ret[i].Local < ret[j].Local
 	})
-	mux.HandleFunc("/expose", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "post only", http.StatusBadRequest)
-			return
-		}
-		var req types.ExposeRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if req.Protocol == "" {
-			req.Protocol = types.TCP
-		}
+	return ret
+}
 
-		// contains unparsed remote field
-		remoteAddr := req.Remote
-
-		// TCP and UDP rely on remote() to preparse the remote field
-		if req.Protocol != types.UNIX && req.Protocol != types.NPIPE {
-			var err error
-			remoteAddr, err = remote(req, r.RemoteAddr)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-
-		if err := f.Expose(req.Protocol, req.Local, remoteAddr); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
-	mux.HandleFunc("/unexpose", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "post only", http.StatusBadRequest)
-			return
-		}
-		var req types.UnexposeRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if req.Protocol == "" {
-			req.Protocol = types.TCP
-		}
-		if err := f.Unexpose(req.Protocol, req.Local); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
-	return mux
+func Remote(req types.ExposeRequest, ip string) (string, error) {
+	return remote(req, ip)
 }
 
 // if the request doesn't have an IP in the remote field, use the IP from the incoming http request.

--- a/pkg/services/forwarder/ports.go
+++ b/pkg/services/forwarder/ports.go
@@ -162,7 +162,7 @@ func (f *PortsForwarder) Expose(protocol types.TransportProtocol, local, remote 
 		switch protocol {
 		case types.UNIX:
 			p.ListenFunc = func(_, socketPath string) (net.Listener, error) {
-				info, err := os.Stat(socketPath)
+				info, err := os.Lstat(socketPath)
 				if err != nil && !os.IsNotExist(err) {
 					// any error other than file does not exist is fatal
 					return nil, err

--- a/pkg/services/forwarder/ports.go
+++ b/pkg/services/forwarder/ports.go
@@ -2,13 +2,11 @@ package forwarder
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"sort"
@@ -35,10 +33,14 @@ type PortsForwarder struct {
 	proxies     map[ProxyKey]proxy
 }
 
+type ProxyInfo struct {
+	Local    string `json:"local"`
+	Remote   string `json:"remote"`
+	Protocol string `json:"protocol"`
+}
+
 type proxy struct {
-	Local      string `json:"local"`
-	Remote     string `json:"remote"`
-	Protocol   string `json:"protocol"`
+	ProxyInfo
 	underlying io.Closer
 }
 
@@ -200,9 +202,11 @@ func (f *PortsForwarder) Expose(protocol types.TransportProtocol, local, remote 
 			}
 		}()
 		f.proxies[key(protocol, local)] = proxy{
-			Protocol: string(protocol),
-			Local:    local,
-			Remote:   remote,
+			ProxyInfo: ProxyInfo{
+				Protocol: string(protocol),
+				Local:    local,
+				Remote:   remote,
+			},
 			underlying: CloseWrapper(func() error {
 				if cleanup != nil {
 					cleanup()
@@ -232,9 +236,11 @@ func (f *PortsForwarder) Expose(protocol types.TransportProtocol, local, remote 
 		}
 		go p.Run()
 		f.proxies[key(protocol, local)] = proxy{
-			Protocol:   "udp",
-			Local:      local,
-			Remote:     remote,
+			ProxyInfo: ProxyInfo{
+				Protocol: "udp",
+				Local:    local,
+				Remote:   remote,
+			},
 			underlying: p,
 		}
 	case types.TCP:
@@ -259,9 +265,11 @@ func (f *PortsForwarder) Expose(protocol types.TransportProtocol, local, remote 
 			}
 		}()
 		f.proxies[key(protocol, local)] = proxy{
-			Protocol:   "tcp",
-			Local:      local,
-			Remote:     remote,
+			ProxyInfo: ProxyInfo{
+				Protocol: "tcp",
+				Local:    local,
+				Remote:   remote,
+			},
 			underlying: &p,
 		}
 	default:
@@ -285,76 +293,24 @@ func (f *PortsForwarder) Unexpose(protocol types.TransportProtocol, local string
 	return proxy.underlying.Close()
 }
 
-func (f *PortsForwarder) Mux() http.Handler {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/all", func(w http.ResponseWriter, _ *http.Request) {
-		f.proxiesLock.Lock()
-		defer f.proxiesLock.Unlock()
-		ret := make([]proxy, 0)
-		for _, proxy := range f.proxies {
-			ret = append(ret, proxy)
+func (f *PortsForwarder) List() []ProxyInfo {
+	f.proxiesLock.Lock()
+	defer f.proxiesLock.Unlock()
+	ret := make([]ProxyInfo, 0)
+	for _, p := range f.proxies {
+		ret = append(ret, p.ProxyInfo)
+	}
+	sort.Slice(ret, func(i, j int) bool {
+		if ret[i].Local == ret[j].Local {
+			return ret[i].Protocol < ret[j].Protocol
 		}
-		sort.Slice(ret, func(i, j int) bool {
-			if ret[i].Local == ret[j].Local {
-				return ret[i].Protocol < ret[j].Protocol
-			}
-			return ret[i].Local < ret[j].Local
-		})
-		_ = json.NewEncoder(w).Encode(ret)
+		return ret[i].Local < ret[j].Local
 	})
-	mux.HandleFunc("/expose", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "post only", http.StatusBadRequest)
-			return
-		}
-		var req types.ExposeRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if req.Protocol == "" {
-			req.Protocol = types.TCP
-		}
+	return ret
+}
 
-		// contains unparsed remote field
-		remoteAddr := req.Remote
-
-		// TCP and UDP rely on remote() to preparse the remote field
-		if req.Protocol != types.UNIX && req.Protocol != types.NPIPE {
-			var err error
-			remoteAddr, err = remote(req, r.RemoteAddr)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-
-		if err := f.Expose(req.Protocol, req.Local, remoteAddr); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
-	mux.HandleFunc("/unexpose", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "post only", http.StatusBadRequest)
-			return
-		}
-		var req types.UnexposeRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if req.Protocol == "" {
-			req.Protocol = types.TCP
-		}
-		if err := f.Unexpose(req.Protocol, req.Local); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
-	return mux
+func Remote(req types.ExposeRequest, ip string) (string, error) {
+	return remote(req, ip)
 }
 
 // if the request doesn't have an IP in the remote field, use the IP from the incoming http request.

--- a/pkg/types/gvproxy_command.go
+++ b/pkg/types/gvproxy_command.go
@@ -33,6 +33,9 @@ type GvproxyCommand struct {
 
 	// SSHPort to access the guest VM
 	SSHPort int
+
+	// GatewayExposeAllProtocols allows all protocols on the gateway /expose API
+	GatewayExposeAllProtocols bool
 }
 
 func NewGvproxyCommand() GvproxyCommand {
@@ -210,6 +213,11 @@ func (c *GvproxyCommand) ToCmdline() []string {
 	// log-file
 	if c.LogFile != "" {
 		args = append(args, "-log-file", c.LogFile)
+	}
+
+	// gateway-expose-all-protocols
+	if c.GatewayExposeAllProtocols {
+		args = append(args, "-gateway-expose-all-protocols")
 	}
 
 	return args

--- a/pkg/virtualnetwork/mux.go
+++ b/pkg/virtualnetwork/mux.go
@@ -1,12 +1,15 @@
 package virtualnetwork
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/services/forwarder"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/inetaf/tcpproxy"
 	log "github.com/sirupsen/logrus"
@@ -15,9 +18,120 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
 )
 
+// Mux returns the full API handler, including the /connect endpoint.
+// Used by the -listen flag for the main control plane API.
+func (n *VirtualNetwork) Mux() *http.ServeMux {
+	mux := n.ServicesMux()
+
+	// Hypervisor connection (packet stream)
+	mux.HandleFunc(types.ConnectPath, func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)
+			return
+		}
+		conn, bufrw, err := hj.Hijack()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer conn.Close()
+
+		if err := bufrw.Flush(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		_ = n.networkSwitch.Accept(context.Background(), conn, n.configuration.Protocol)
+	})
+
+	return mux
+}
+
+// ServicesMux returns the API handler without the /connect endpoint.
+// Used by the -services flag.
 func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 	mux := http.NewServeMux()
-	mux.Handle("/services/", http.StripPrefix("/services", n.servicesMux))
+
+	// Port Forwarding
+	mux.HandleFunc("/services/forwarder/all", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(n.forwarder.List())
+	})
+	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "post only", http.StatusBadRequest)
+			return
+		}
+		var req types.ExposeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Protocol == "" {
+			req.Protocol = types.TCP
+		}
+
+		remoteAddr := req.Remote
+		if req.Protocol != types.UNIX && req.Protocol != types.NPIPE {
+			var err error
+			remoteAddr, err = forwarder.Remote(req, r.RemoteAddr)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+
+		if err := n.forwarder.Expose(req.Protocol, req.Local, remoteAddr); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/services/forwarder/unexpose", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "post only", http.StatusBadRequest)
+			return
+		}
+		var req types.UnexposeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Protocol == "" {
+			req.Protocol = types.TCP
+		}
+		if err := n.forwarder.Unexpose(req.Protocol, req.Local); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// DNS Management
+	mux.HandleFunc("/services/dns/all", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(n.dnsServer.Zones())
+	})
+	mux.HandleFunc("/services/dns/add", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "post only", http.StatusBadRequest)
+			return
+		}
+		var req types.Zone
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		n.dnsServer.AddZone(req)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// DHCP
+	mux.HandleFunc("/services/dhcp/leases", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(n.dhcpServer.Leases())
+	})
+
+	// Network Information
 	mux.HandleFunc("/stats", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(statsAsJSON(n.networkSwitch.Sent, n.networkSwitch.Received, n.stack.Stats()))
 	})
@@ -27,6 +141,8 @@ func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 	mux.HandleFunc("/leases", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(n.ipPool.Leases())
 	})
+
+	// Tunneling
 	mux.HandleFunc("/tunnel", func(w http.ResponseWriter, r *http.Request) {
 		ip := r.URL.Query().Get("ip")
 		if ip == "" {
@@ -77,30 +193,54 @@ func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 		}
 		remote.HandleConn(conn)
 	})
+
 	return mux
 }
 
-func (n *VirtualNetwork) Mux() *http.ServeMux {
-	mux := n.ServicesMux()
-	mux.HandleFunc(types.ConnectPath, func(w http.ResponseWriter, _ *http.Request) {
-		hj, ok := w.(http.Hijacker)
-		if !ok {
-			http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)
-			return
-		}
-		conn, bufrw, err := hj.Hijack()
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		defer conn.Close()
+// GatewayMux returns the restricted API handler for the VM-facing gateway.
+// Only exposes port forwarding endpoints. Unix/npipe protocols are blocked
+// unless allowAllProtocols is true.
+func (n *VirtualNetwork) GatewayMux(allowAllProtocols bool) *http.ServeMux {
+	mux := http.NewServeMux()
+	vnMux := n.Mux()
 
-		if err := bufrw.Flush(); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+	mux.Handle("/services/forwarder/all", vnMux)
+	if allowAllProtocols {
+		mux.Handle("/services/forwarder/expose", vnMux)
+	} else {
+		mux.Handle("/services/forwarder/expose", GatewayProtocolFilter(vnMux))
+	}
+	mux.Handle("/services/forwarder/unexpose", vnMux)
 
-		_ = n.networkSwitch.Accept(context.Background(), conn, n.configuration.Protocol)
-	})
 	return mux
+}
+
+// GatewayProtocolFilter blocks unix and npipe protocols on the gateway API.
+func GatewayProtocolFilter(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Protocol string `json:"protocol"`
+		}
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		r.Body.Close()
+
+		if err := json.Unmarshal(bodyBytes, &req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if req.Protocol == "unix" || req.Protocol == "npipe" {
+			log.Warnf("blocked %s protocol on gateway API", req.Protocol)
+			http.Error(w, "unix and npipe protocols are not allowed on the gateway API", http.StatusForbidden)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		next.ServeHTTP(w, r)
+	})
 }

--- a/pkg/virtualnetwork/mux.go
+++ b/pkg/virtualnetwork/mux.go
@@ -1,12 +1,15 @@
 package virtualnetwork
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/services/forwarder"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/inetaf/tcpproxy"
 	log "github.com/sirupsen/logrus"
@@ -15,9 +18,120 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
 )
 
+// Mux returns the full API handler, including the /connect endpoint.
+// Used by the -listen flag for the main control plane API.
+func (n *VirtualNetwork) Mux() *http.ServeMux {
+	mux := n.ServicesMux()
+
+	// Hypervisor connection (packet stream)
+	mux.HandleFunc(types.ConnectPath, func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)
+			return
+		}
+		conn, bufrw, err := hj.Hijack()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer conn.Close()
+
+		if err := bufrw.Flush(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		_ = n.networkSwitch.Accept(context.Background(), conn, n.configuration.Protocol)
+	})
+
+	return mux
+}
+
+// ServicesMux returns the API handler without the /connect endpoint.
+// Used by the -services flag.
 func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 	mux := http.NewServeMux()
-	mux.Handle("/services/", http.StripPrefix("/services", n.servicesMux))
+
+	// Port Forwarding
+	mux.HandleFunc("/services/forwarder/all", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(n.forwarder.List())
+	})
+	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "post only", http.StatusBadRequest)
+			return
+		}
+		var req types.ExposeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Protocol == "" {
+			req.Protocol = types.TCP
+		}
+
+		remoteAddr := req.Remote
+		if req.Protocol != types.UNIX && req.Protocol != types.NPIPE {
+			var err error
+			remoteAddr, err = forwarder.Remote(req, r.RemoteAddr)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+
+		if err := n.forwarder.Expose(req.Protocol, req.Local, remoteAddr); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/services/forwarder/unexpose", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "post only", http.StatusBadRequest)
+			return
+		}
+		var req types.UnexposeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Protocol == "" {
+			req.Protocol = types.TCP
+		}
+		if err := n.forwarder.Unexpose(req.Protocol, req.Local); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// DNS Management
+	mux.HandleFunc("/services/dns/all", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(n.dnsServer.Zones())
+	})
+	mux.HandleFunc("/services/dns/add", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "post only", http.StatusBadRequest)
+			return
+		}
+		var req types.Zone
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		n.dnsServer.AddZone(req)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// DHCP
+	mux.HandleFunc("/services/dhcp/leases", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(n.dhcpServer.Leases())
+	})
+
+	// Network Information
 	mux.HandleFunc("/stats", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(statsAsJSON(n.networkSwitch.Sent, n.networkSwitch.Received, n.stack.Stats()))
 	})
@@ -27,6 +141,8 @@ func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 	mux.HandleFunc("/leases", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(n.ipPool.Leases())
 	})
+
+	// Tunneling
 	mux.HandleFunc("/tunnel", func(w http.ResponseWriter, r *http.Request) {
 		ip := r.URL.Query().Get("ip")
 		if ip == "" {
@@ -77,30 +193,56 @@ func (n *VirtualNetwork) ServicesMux() *http.ServeMux {
 		}
 		remote.HandleConn(conn)
 	})
+
 	return mux
 }
 
-func (n *VirtualNetwork) Mux() *http.ServeMux {
-	mux := n.ServicesMux()
-	mux.HandleFunc(types.ConnectPath, func(w http.ResponseWriter, _ *http.Request) {
-		hj, ok := w.(http.Hijacker)
-		if !ok {
-			http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)
-			return
-		}
-		conn, bufrw, err := hj.Hijack()
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		defer conn.Close()
+// GatewayMux returns the restricted API handler for the VM-facing gateway.
+// Only exposes port forwarding endpoints. Only tcp and udp protocols are allowed
+// unless allowAllProtocols is true.
+func (n *VirtualNetwork) GatewayMux(allowAllProtocols bool) *http.ServeMux {
+	mux := http.NewServeMux()
+	servicesMux := n.ServicesMux()
 
-		if err := bufrw.Flush(); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+	mux.Handle("/services/forwarder/all", servicesMux)
+	if allowAllProtocols {
+		mux.Handle("/services/forwarder/expose", servicesMux)
+	} else {
+		mux.Handle("/services/forwarder/expose", GatewayProtocolFilter(servicesMux))
+	}
+	mux.Handle("/services/forwarder/unexpose", servicesMux)
 
-		_ = n.networkSwitch.Accept(context.Background(), conn, n.configuration.Protocol)
-	})
 	return mux
+}
+
+// GatewayProtocolFilter restricts the gateway API to only allow tcp and udp protocols.
+func GatewayProtocolFilter(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Protocol string `json:"protocol"`
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		r.Body.Close()
+
+		if err := json.Unmarshal(bodyBytes, &req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// Empty protocol is allowed because the /expose handler defaults it to tcp
+		if req.Protocol != "tcp" && req.Protocol != "udp" && req.Protocol != "" {
+			log.Warnf("blocked %s protocol on gateway API", req.Protocol)
+			http.Error(w, "only tcp and udp protocols are allowed on the gateway API", http.StatusForbidden)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		next.ServeHTTP(w, r)
+	})
 }

--- a/pkg/virtualnetwork/services.go
+++ b/pkg/virtualnetwork/services.go
@@ -2,7 +2,6 @@ package virtualnetwork
 
 import (
 	"net"
-	"net/http"
 	"strings"
 	"sync"
 
@@ -21,7 +20,7 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
 )
 
-func addServices(configuration *types.Configuration, s *stack.Stack, ipPool *tap.IPPool) (http.Handler, error) {
+func addServices(configuration *types.Configuration, s *stack.Stack, ipPool *tap.IPPool) (*forwarder.PortsForwarder, *dns.Server, *dhcp.Server, error) {
 	var natLock sync.Mutex
 	translation := parseNATTable(configuration)
 
@@ -32,25 +31,22 @@ func addServices(configuration *types.Configuration, s *stack.Stack, ipPool *tap
 	icmpForwarder := forwarder.ICMP(s, translation, &natLock)
 	s.SetTransportProtocolHandler(icmp.ProtocolNumber4, icmpForwarder.HandlePacket)
 
-	dnsMux, err := dnsServer(configuration, s)
+	dnsServer, err := createDNSServer(configuration, s)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 
-	dhcpMux, err := dhcpServer(configuration, s, ipPool)
+	dhcpServer, err := createDHCPServer(configuration, s, ipPool)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 
-	forwarderMux, err := forwardHostVM(configuration, s)
+	fw, err := createForwarder(configuration, s)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
-	mux := http.NewServeMux()
-	mux.Handle("/forwarder/", http.StripPrefix("/forwarder", forwarderMux))
-	mux.Handle("/dhcp/", http.StripPrefix("/dhcp", dhcpMux))
-	mux.Handle("/dns/", http.StripPrefix("/dns", dnsMux))
-	return mux, nil
+
+	return fw, dnsServer, dhcpServer, nil
 }
 
 func parseNATTable(configuration *types.Configuration) map[tcpip.Address]tcpip.Address {
@@ -61,7 +57,7 @@ func parseNATTable(configuration *types.Configuration) map[tcpip.Address]tcpip.A
 	return translation
 }
 
-func dnsServer(configuration *types.Configuration, s *stack.Stack) (http.Handler, error) {
+func createDNSServer(configuration *types.Configuration, s *stack.Stack) (*dns.Server, error) {
 	udpConn, err := gonet.DialUDP(s, &tcpip.FullAddress{
 		NIC:  1,
 		Addr: tcpip.AddrFrom4Slice(net.ParseIP(configuration.GatewayIP).To4()),
@@ -95,10 +91,10 @@ func dnsServer(configuration *types.Configuration, s *stack.Stack) (http.Handler
 			log.Error(err)
 		}
 	}()
-	return server.Mux(), nil
+	return server, nil
 }
 
-func dhcpServer(configuration *types.Configuration, s *stack.Stack, ipPool *tap.IPPool) (http.Handler, error) {
+func createDHCPServer(configuration *types.Configuration, s *stack.Stack, ipPool *tap.IPPool) (*dhcp.Server, error) {
 	server, err := dhcp.New(configuration, s, ipPool)
 	if err != nil {
 		return nil, err
@@ -106,10 +102,10 @@ func dhcpServer(configuration *types.Configuration, s *stack.Stack, ipPool *tap.
 	go func() {
 		log.Error(server.Serve())
 	}()
-	return server.Mux(), nil
+	return server, nil
 }
 
-func forwardHostVM(configuration *types.Configuration, s *stack.Stack) (http.Handler, error) {
+func createForwarder(configuration *types.Configuration, s *stack.Stack) (*forwarder.PortsForwarder, error) {
 	fw := forwarder.NewPortsForwarder(s)
 	for local, remote := range configuration.Forwards {
 		if strings.HasPrefix(local, "udp:") {
@@ -122,5 +118,5 @@ func forwardHostVM(configuration *types.Configuration, s *stack.Stack) (http.Han
 			}
 		}
 	}
-	return fw.Mux(), nil
+	return fw, nil
 }

--- a/pkg/virtualnetwork/virtualnetwork.go
+++ b/pkg/virtualnetwork/virtualnetwork.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"net/http"
 	"os"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/notification"
+	"github.com/containers/gvisor-tap-vsock/pkg/services/dhcp"
+	"github.com/containers/gvisor-tap-vsock/pkg/services/dns"
+	"github.com/containers/gvisor-tap-vsock/pkg/services/forwarder"
 	"github.com/containers/gvisor-tap-vsock/pkg/tap"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"gvisor.dev/gvisor/pkg/tcpip"
@@ -25,8 +27,10 @@ type VirtualNetwork struct {
 	configuration *types.Configuration
 	stack         *stack.Stack
 	networkSwitch *tap.Switch
-	servicesMux   http.Handler
 	ipPool        *tap.IPPool
+	forwarder     *forwarder.PortsForwarder
+	dnsServer     *dns.Server
+	dhcpServer    *dhcp.Server
 }
 
 func (n *VirtualNetwork) SetNotificationSender(notificationSender *notification.NotificationSender) {
@@ -78,7 +82,7 @@ func New(configuration *types.Configuration) (*VirtualNetwork, error) {
 		return nil, fmt.Errorf("cannot create network stack: %w", err)
 	}
 
-	mux, err := addServices(configuration, stack, ipPool)
+	fw, dnsServer, dhcpServer, err := addServices(configuration, stack, ipPool)
 	if err != nil {
 		return nil, fmt.Errorf("cannot add network services: %w", err)
 	}
@@ -87,8 +91,10 @@ func New(configuration *types.Configuration) (*VirtualNetwork, error) {
 		configuration: configuration,
 		stack:         stack,
 		networkSwitch: networkSwitch,
-		servicesMux:   mux,
 		ipPool:        ipPool,
+		forwarder:     fw,
+		dnsServer:     dnsServer,
+		dhcpServer:    dhcpServer,
 	}, nil
 }
 

--- a/pkg/virtualnetwork/virtualnetwork.go
+++ b/pkg/virtualnetwork/virtualnetwork.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"net/http"
 	"os"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/notification"
+	"github.com/containers/gvisor-tap-vsock/pkg/services/dhcp"
+	"github.com/containers/gvisor-tap-vsock/pkg/services/dns"
+	"github.com/containers/gvisor-tap-vsock/pkg/services/forwarder"
 	"github.com/containers/gvisor-tap-vsock/pkg/tap"
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"gvisor.dev/gvisor/pkg/tcpip"
@@ -25,8 +27,10 @@ type VirtualNetwork struct {
 	configuration *types.Configuration
 	stack         *stack.Stack
 	networkSwitch *tap.Switch
-	servicesMux   http.Handler
 	ipPool        *tap.IPPool
+	forwarder     *forwarder.PortsForwarder
+	dnsServer     *dns.Server
+	dhcpServer    *dhcp.Server
 }
 
 func (n *VirtualNetwork) SetNotificationSender(notificationSender *notification.NotificationSender) {
@@ -80,7 +84,7 @@ func New(configuration *types.Configuration) (*VirtualNetwork, error) {
 		return nil, fmt.Errorf("cannot create network stack: %w", err)
 	}
 
-	mux, err := addServices(configuration, stack, ipPool)
+	fw, dnsServer, dhcpServer, err := addServices(configuration, stack, ipPool)
 	if err != nil {
 		return nil, fmt.Errorf("cannot add network services: %w", err)
 	}
@@ -89,8 +93,10 @@ func New(configuration *types.Configuration) (*VirtualNetwork, error) {
 		configuration: configuration,
 		stack:         stack,
 		networkSwitch: networkSwitch,
-		servicesMux:   mux,
 		ipPool:        ipPool,
+		forwarder:     fw,
+		dnsServer:     dnsServer,
+		dhcpServer:    dhcpServer,
 	}, nil
 }
 

--- a/test-qemu/suite_test.go
+++ b/test-qemu/suite_test.go
@@ -65,6 +65,7 @@ func gvproxyCmd() *exec.Cmd {
 	cmd := types.NewGvproxyCommand()
 	cmd.AddEndpoint(fmt.Sprintf("unix://%s", sock))
 	cmd.AddQemuSocket("tcp://" + net.JoinHostPort("127.0.0.1", strconv.Itoa(qemuPort)))
+	cmd.GatewayExposeAllProtocols = true
 	cmd.AddForwardSock(forwardSock)
 	cmd.AddForwardDest(podmanSock)
 	cmd.AddForwardUser(ignitionUser)

--- a/test-qemu/suite_test.go
+++ b/test-qemu/suite_test.go
@@ -65,6 +65,9 @@ func gvproxyCmd() *exec.Cmd {
 	cmd := types.NewGvproxyCommand()
 	cmd.AddEndpoint(fmt.Sprintf("unix://%s", sock))
 	cmd.AddQemuSocket("tcp://" + net.JoinHostPort("127.0.0.1", strconv.Itoa(qemuPort)))
+	// Required for unix socket forwarding tests (e.g. unix-to-tcp, unix-to-unix).
+	// By default, only tcp and udp are allowed on the gateway API.
+	// The restricted case is covered by unit tests in cmd/gvproxy/gateway_test.go.
 	cmd.GatewayExposeAllProtocols = true
 	cmd.AddForwardSock(forwardSock)
 	cmd.AddForwardDest(podmanSock)


### PR DESCRIPTION
Note: this PR is based on the branch that fixes RHDESK-550 (https://github.com/containers/gvisor-tap-vsock/pull/681)

Move all REST API endpoint registrations into a single file
(pkg/virtualnetwork/mux.go) to make the full API surface visible
more clearly. Previously, handlers were scattered across 6 files
with a 4-level mux composition chain using StripPrefix.

The three API surfaces are now defined as explicit mux constructors:
- Mux(): full API including /connect (for -listen endpoints)
- ServicesMux(): everything except /connect (for -services)
- GatewayMux(): only forwarder endpoints (for gateway 192.168.127.1)

Service packages (forwarder, DNS, DHCP) no longer define HTTP
handlers. Instead, they export business logic methods (List, Expose,
Unexpose, Zones, AddZone, Leases) that mux.go calls from its
handlers. This removes their dependency on net/http.

The gateway protocol filter (GatewayProtocolFilter) moves from
cmd/gvproxy/main.go to pkg/virtualnetwork/mux.go alongside the
other API definitions.

No behavioral changes — all endpoint paths, request/response
formats, and error handling remain identical.