### PR TITLE
fix(dns): forward SOA/PTR/AAAA and other unhandled query types

### DIFF
--- a/pkg/services/dns/dns.go
+++ b/pkg/services/dns/dns.go
@@ -27,6 +27,11 @@ type dnsHandler struct {
 	zones     []types.Zone
 	zonesLock sync.RWMutex
 	upstream  upstreamResolver
+	// nameservers are the host's upstream DNS servers ("ip:port") used to
+	// forward raw queries for record types that Go's net.Resolver cannot
+	// look up directly (SOA, PTR, AAAA, CAA, ...).
+	nameservers []string
+	client      *dns.Client
 }
 
 func (h *dnsHandler) handle(w dns.ResponseWriter, r *dns.Msg, responseMessageSize int) {
@@ -232,9 +237,62 @@ func (h *dnsHandler) addAnswers(m *dns.Msg) {
 					Txt: splitTxt(txt),
 				})
 			}
-
+		default:
+			// Record types not handled above (SOA, PTR, AAAA, CAA, ...) are
+			// forwarded verbatim to the host's upstream nameservers, since
+			// Go's net.Resolver has no generic query for them.
+			h.addAnswersFromNameservers(m, q)
 		}
 	}
+}
+
+// addAnswersFromNameservers forwards the raw query q to the host's upstream
+// nameservers and copies the response back into m. It is used as the fallback
+// for record types that the typed net.Resolver cannot resolve.
+func (h *dnsHandler) addAnswersFromNameservers(m *dns.Msg, q dns.Question) {
+	if len(h.nameservers) == 0 {
+		// No upstream discovered (e.g. Windows, no /etc/resolv.conf): preserve
+		// the previous behavior (empty NOERROR) and leave the Rcode untouched.
+		return
+	}
+
+	req := new(dns.Msg)
+	req.SetQuestion(q.Name, q.Qtype)
+	req.RecursionDesired = true
+
+	for _, ns := range h.nameservers {
+		resp, _, err := h.client.Exchange(req, ns)
+		if err != nil || resp == nil {
+			continue
+		}
+		// Copy the answer and authority sections. A NODATA response carries the
+		// zone SOA in the authority (Ns) section. Extra is intentionally not
+		// copied: it may hold an OPT/EDNS0 pseudo-record that would conflict
+		// with the EDNS handling in handle().
+		m.Answer = append(m.Answer, resp.Answer...)
+		m.Ns = append(m.Ns, resp.Ns...)
+		m.Rcode = resp.Rcode
+		return
+	}
+
+	// The upstream servers are known but none could be reached.
+	m.Rcode = dns.RcodeServerFailure
+}
+
+// hostNameservers returns the upstream DNS servers ("ip:port") configured on
+// the host. /etc/resolv.conf exists on Linux and macOS; on other platforms
+// (e.g. Windows) it is absent and an empty list is returned.
+func hostNameservers() []string {
+	conf, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	if err != nil {
+		log.Warnf("cannot read /etc/resolv.conf, DNS queries for SOA/PTR/AAAA and other unhandled types will not be forwarded: %v", err)
+		return nil
+	}
+	servers := make([]string, 0, len(conf.Servers))
+	for _, s := range conf.Servers {
+		servers = append(servers, net.JoinHostPort(s, conf.Port))
+	}
+	return servers
 }
 
 type Server struct {
@@ -251,7 +309,12 @@ func New(udpConn net.PacketConn, tcpLn net.Listener, zones []types.Zone) (*Serve
 }
 
 func NewWithUpstreamResolver(udpConn net.PacketConn, tcpLn net.Listener, zones []types.Zone, upstream upstreamResolver) (*Server, error) {
-	handler := &dnsHandler{zones: zones, upstream: upstream}
+	handler := &dnsHandler{
+		zones:       zones,
+		upstream:    upstream,
+		nameservers: hostNameservers(),
+		client:      &dns.Client{},
+	}
 	return &Server{udpConn: udpConn, tcpLn: tcpLn, handler: handler}, nil
 }
 

--- a/pkg/services/dns/dns_test.go
+++ b/pkg/services/dns/dns_test.go
@@ -312,6 +312,90 @@ var _ = ginkgo.Describe("TXT records", func() {
 
 })
 
+var _ = ginkgo.Describe("forwarding unhandled record types", func() {
+	var (
+		mockSrv *mockdns.Server
+		server  *Server
+	)
+
+	const (
+		aaaaDomain = "aaaa.example.org."
+		ptrName    = "2.1.168.192.in-addr.arpa."
+		ptrTarget  = "host.example.org."
+	)
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		mockSrv, err = mockdns.NewServer(map[string]mockdns.Zone{
+			aaaaDomain: {
+				AAAA: []string{"fe80::1"},
+			},
+			ptrName: {
+				PTR: []string{ptrTarget},
+			},
+		}, false)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		server, err = New(nil, nil, []types.Zone{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		// Point the raw forwarder at the mock upstream server.
+		server.handler.nameservers = []string{mockSrv.LocalAddr().String()}
+	})
+
+	ginkgo.AfterEach(func() {
+		if mockSrv != nil {
+			_ = mockSrv.Close()
+		}
+	})
+
+	query := func(name string, qtype uint16) *dns.Msg {
+		m := new(dns.Msg)
+		m.SetQuestion(name, qtype)
+		server.handler.addAnswers(m)
+		return m
+	}
+
+	ginkgo.It("should forward SOA queries", func() {
+		m := query("example.org.", dns.TypeSOA)
+		gomega.Expect(m.Rcode).To(gomega.Equal(dns.RcodeSuccess))
+		gomega.Expect(m.Answer).To(gomega.HaveLen(1))
+		_, ok := m.Answer[0].(*dns.SOA)
+		gomega.Expect(ok).To(gomega.BeTrue(), "expected an SOA answer")
+	})
+
+	ginkgo.It("should forward AAAA queries", func() {
+		m := query(aaaaDomain, dns.TypeAAAA)
+		gomega.Expect(m.Rcode).To(gomega.Equal(dns.RcodeSuccess))
+		gomega.Expect(m.Answer).To(gomega.HaveLen(1))
+		aaaa, ok := m.Answer[0].(*dns.AAAA)
+		gomega.Expect(ok).To(gomega.BeTrue(), "expected an AAAA answer")
+		gomega.Expect(aaaa.AAAA.String()).To(gomega.Equal("fe80::1"))
+	})
+
+	ginkgo.It("should forward PTR queries", func() {
+		m := query(ptrName, dns.TypePTR)
+		gomega.Expect(m.Rcode).To(gomega.Equal(dns.RcodeSuccess))
+		gomega.Expect(m.Answer).To(gomega.HaveLen(1))
+		ptr, ok := m.Answer[0].(*dns.PTR)
+		gomega.Expect(ok).To(gomega.BeTrue(), "expected a PTR answer")
+		gomega.Expect(ptr.Ptr).To(gomega.Equal(ptrTarget))
+	})
+
+	ginkgo.It("should return SERVFAIL when the upstream cannot be reached", func() {
+		server.handler.client = &dns.Client{Timeout: 200 * time.Millisecond}
+		server.handler.nameservers = []string{"127.0.0.1:1"} // nothing listening
+		m := query("example.org.", dns.TypeCAA)
+		gomega.Expect(m.Rcode).To(gomega.Equal(dns.RcodeServerFailure))
+	})
+
+	ginkgo.It("should keep NOERROR with no answers when no upstream is configured", func() {
+		server.handler.nameservers = nil
+		m := query("example.org.", dns.TypeCAA)
+		gomega.Expect(m.Rcode).To(gomega.Equal(dns.RcodeSuccess))
+		gomega.Expect(m.Answer).To(gomega.BeEmpty())
+	})
+})
+
 type ARecord struct {
 	name        string
 	expectedIPs []string


### PR DESCRIPTION
The resolver's addAnswers switch only handled A/CNAME/MX/NS/SRV/TXT and had no default case, so queries for SOA, PTR, AAAA, CAA and similar types fell through and returned an empty NOERROR at 0 msec without ever contacting an upstream. This broke guest tools relying on those records (e.g. cert-manager ACME DNS-01 challenges need SOA).

Add a default branch that forwards the raw query to the host's upstream nameservers (from /etc/resolv.conf) via the miekg/dns client and copies the answer/authority sections back. Go's net.Resolver has no generic query for these types, so raw forwarding is required.

When no upstream is discovered (e.g. Windows without /etc/resolv.conf) the previous empty-NOERROR behavior is preserved; when servers are known but unreachable the reply is SERVFAIL.

Fixes #612