### PR TITLE
Make TCP forwarder max in-flight connections and connect timeout configurable

### DIFF
--- a/cmd/gvproxy/config_test.go
+++ b/cmd/gvproxy/config_test.go
@@ -697,5 +697,28 @@ interfaces:
     stdio: accept
 `,
 		},
+		{
+			CaseName: "config: tcp forwarder settings",
+			Args:     []string{"-config", "config.yaml"},
+			InputConfig: `stack:
+    tcpMaxInFlight: 500
+    tcpConnectTimeout: 10
+`,
+			ResultConfig: `log-level: info
+stack:
+    mtu: 1500
+    subnet: 192.168.127.0/24
+    gatewayIP: 192.168.127.1
+    deviceIP: 192.168.127.2
+    hostIP: 192.168.127.254
+    gatewayMacAddress: 5a:94:ef:e4:0c:dd
+    nat:
+        192.168.127.254: 127.0.0.1
+    gatewayVirtualIPs:
+        - 192.168.127.254
+    tcpMaxInFlight: 500
+    tcpConnectTimeout: 10
+`,
+		},
 	}
 }

--- a/pkg/services/forwarder/tcp.go
+++ b/pkg/services/forwarder/tcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/inetaf/tcpproxy"
 	log "github.com/sirupsen/logrus"
@@ -15,10 +16,21 @@ import (
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
-const linkLocalSubnet = "169.254.0.0/16"
+const (
+	linkLocalSubnet = "169.254.0.0/16"
 
-func TCP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mutex, ec2MetadataAccess bool) *tcp.Forwarder {
-	return tcp.NewForwarder(s, 0, 10, func(r *tcp.ForwarderRequest) {
+	DefaultTCPMaxInFlight    = 128
+	DefaultTCPConnectTimeout = 30 * time.Second
+)
+
+func TCP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mutex, ec2MetadataAccess bool, maxInFlight int, connectTimeout time.Duration) *tcp.Forwarder {
+	if maxInFlight <= 0 {
+		maxInFlight = DefaultTCPMaxInFlight
+	}
+	if connectTimeout <= 0 {
+		connectTimeout = DefaultTCPConnectTimeout
+	}
+	return tcp.NewForwarder(s, 0, maxInFlight, func(r *tcp.ForwarderRequest) {
 		localAddress := r.ID().LocalAddress
 
 		if (!ec2MetadataAccess) && linkLocal().Contains(localAddress) {
@@ -31,9 +43,9 @@ func TCP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mute
 			localAddress = replaced
 		}
 		natLock.Unlock()
-		outbound, err := net.Dial("tcp", net.JoinHostPort(localAddress.String(), fmt.Sprint(r.ID().LocalPort)))
+		outbound, err := net.DialTimeout("tcp", net.JoinHostPort(localAddress.String(), fmt.Sprint(r.ID().LocalPort)), connectTimeout)
 		if err != nil {
-			log.Tracef("net.Dial() = %v", err)
+			log.Tracef("net.DialTimeout() = %v", err)
 			r.Complete(true)
 			return
 		}

--- a/pkg/services/forwarder/tcp.go
+++ b/pkg/services/forwarder/tcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/inetaf/tcpproxy"
 	log "github.com/sirupsen/logrus"
@@ -15,10 +16,21 @@ import (
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
-const linkLocalSubnet = "169.254.0.0/16"
+const (
+	linkLocalSubnet = "169.254.0.0/16"
 
-func TCP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mutex, ec2MetadataAccess bool) *tcp.Forwarder {
-	return tcp.NewForwarder(s, 0, 10, func(r *tcp.ForwarderRequest) {
+	defaultTCPMaxInFlight    = 128
+	defaultTCPConnectTimeout = 30 * time.Second
+)
+
+func TCP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mutex, ec2MetadataAccess bool, maxInFlight int, connectTimeout time.Duration) *tcp.Forwarder {
+	if maxInFlight <= 0 {
+		maxInFlight = defaultTCPMaxInFlight
+	}
+	if connectTimeout <= 0 {
+		connectTimeout = defaultTCPConnectTimeout
+	}
+	return tcp.NewForwarder(s, 0, maxInFlight, func(r *tcp.ForwarderRequest) {
 		localAddress := r.ID().LocalAddress
 
 		if (!ec2MetadataAccess) && linkLocal().Contains(localAddress) {
@@ -31,9 +43,9 @@ func TCP(s *stack.Stack, nat map[tcpip.Address]tcpip.Address, natLock *sync.Mute
 			localAddress = replaced
 		}
 		natLock.Unlock()
-		outbound, err := net.Dial("tcp", net.JoinHostPort(localAddress.String(), fmt.Sprint(r.ID().LocalPort)))
+		outbound, err := net.DialTimeout("tcp", net.JoinHostPort(localAddress.String(), fmt.Sprint(r.ID().LocalPort)), connectTimeout)
 		if err != nil {
-			log.Tracef("net.Dial() = %v", err)
+			log.Tracef("net.DialTimeout() = %v", err)
 			r.Complete(true)
 			return
 		}

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -59,6 +59,12 @@ type Configuration struct {
 
 	// EC2 Metadata Service Access
 	Ec2MetadataAccess bool `yaml:"ec2MetadataAccess,omitempty"`
+
+	// Maximum number of in-flight TCP connection forwarding attempts (default: 128)
+	TCPMaxInFlight int `yaml:"tcpMaxInFlight,omitempty"`
+
+	// Timeout in seconds for outbound TCP connection attempts (default: 30)
+	TCPConnectTimeout int `yaml:"tcpConnectTimeout,omitempty"`
 }
 
 type Protocol string

--- a/pkg/virtualnetwork/services.go
+++ b/pkg/virtualnetwork/services.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/services/dhcp"
 	"github.com/containers/gvisor-tap-vsock/pkg/services/dns"
@@ -25,7 +26,8 @@ func addServices(configuration *types.Configuration, s *stack.Stack, ipPool *tap
 	var natLock sync.Mutex
 	translation := parseNATTable(configuration)
 
-	tcpForwarder := forwarder.TCP(s, translation, &natLock, configuration.Ec2MetadataAccess)
+	tcpForwarder := forwarder.TCP(s, translation, &natLock, configuration.Ec2MetadataAccess,
+		configuration.TCPMaxInFlight, time.Duration(configuration.TCPConnectTimeout)*time.Second)
 	s.SetTransportProtocolHandler(tcp.ProtocolNumber, tcpForwarder.HandlePacket)
 	udpForwarder := forwarder.UDP(s, translation, &natLock, configuration.Ec2MetadataAccess)
 	s.SetTransportProtocolHandler(udp.ProtocolNumber, udpForwarder.HandlePacket)


### PR DESCRIPTION
The hardcoded limit of 10 in-flight TCP connections caused all outgoing TCP to stall when a few destinations were unresponsive, as each blocked slot waited for the OS connect timeout (75s on macOS). Raise the default to 128, add a 30s connect timeout via net.DialTimeout, and expose both values as configuration options (tcpMaxInFlight, tcpConnectTimeout).


fix: https://github.com/containers/gvisor-tap-vsock/issues/676