### PR TITLE
fix(win-sshproxy): don't stop execution when setup log fails

### DIFF
--- a/cmd/win-sshproxy/main.go
+++ b/cmd/win-sshproxy/main.go
@@ -56,15 +56,19 @@ func main() {
 	}
 
 	// Attempt to set up logging with the event log service.
-	// If it fails because the Windows Event Log Service is not running, show a warning
-	// and continue execution. There could be a reason why user disabled the Event Log.
+	// If it fails because the Windows Event Log Service is not running,
+	// because the user isn't allowed to create events, or for any other
+	// reason, show a warning and continue execution. Failing to setup
+	// logging shouldn't prevent execution.
 	log, err := setupLogging(args[0])
 	if err != nil {
-		if errors.Is(err, syscall.Errno(RPC_S_SERVER_UNAVAILABLE)) {
+		switch {
+		case errors.Is(err, syscall.Errno(RPC_S_SERVER_UNAVAILABLE)):
 			logrus.Warn("RPC server is unavailable, continuing without event log")
-		} else {
-			logrus.Errorf("Error setting up logging: %v", err)
-			os.Exit(1)
+		case errors.Is(err, syscall.ERROR_ACCESS_DENIED):
+			logrus.Warn("register to Windows event log denied, continuing without event log")
+		default:
+			logrus.Warnf("Error setting up logging: %v", err)
 		}
 	}
 

--- a/cmd/win-sshproxy/main.go
+++ b/cmd/win-sshproxy/main.go
@@ -191,7 +191,7 @@ func setupProxies(ctx context.Context, g *errgroup.Group, sources []string, dest
 
 func saveThreadId() (uint32, error) {
 	path := filepath.Join(stateDir, "win-sshproxy.tid")
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0o644)
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/win-sshproxy/main.go
+++ b/cmd/win-sshproxy/main.go
@@ -56,15 +56,19 @@ func main() {
 	}
 
 	// Attempt to set up logging with the event log service.
-	// If it fails because the Windows Event Log Service is not running, show a warning
-	// and continue execution. There could be a reason why user disabled the Event Log.
+	// If it fails because the Windows Event Log Service is not running,
+	// because the user isn't allowed to create events, or for any other
+	// reason, show a warning and continue execution. Failing to setup
+	// logging shouldn't prevent execution.
 	log, err := setupLogging(args[0])
 	if err != nil {
-		if errors.Is(err, syscall.Errno(RPC_S_SERVER_UNAVAILABLE)) {
-			logrus.Warn("RPC server is unavailable, continuing without event log")
-		} else {
-			logrus.Errorf("Error setting up logging: %v", err)
-			os.Exit(1)
+		switch {
+		case errors.Is(err, syscall.Errno(RPC_S_SERVER_UNAVAILABLE)):
+			logrus.Warnf("RPC server is unavailable, continuing without event log: %v", err)
+		case errors.Is(err, syscall.ERROR_ACCESS_DENIED):
+			logrus.Warnf("register to Windows event log denied, continuing without event log: %v", err)
+		default:
+			logrus.Warnf("Error setting up logging: %v", err)
 		}
 	}
 
@@ -187,7 +191,7 @@ func setupProxies(ctx context.Context, g *errgroup.Group, sources []string, dest
 
 func saveThreadId() (uint32, error) {
 	path := filepath.Join(stateDir, "win-sshproxy.tid")
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0o644)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sshclient/ssh_forwarder.go
+++ b/pkg/sshclient/ssh_forwarder.go
@@ -117,7 +117,7 @@ func listenUnix(socketURI *url.URL) (net.Listener, error) {
 		return nil, err
 	}
 
-	oldmask := fs.Umask(0177)
+	oldmask := fs.Umask(0o177)
 	defer fs.Umask(oldmask)
 	listener, err := net.Listen("unix", path)
 	if err != nil {

--- a/test-utils/ignition.go
+++ b/test-utils/ignition.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	mode    = 0644
-	dirMode = 0744
+	mode    = 0o644
+	dirMode = 0o744
 	root    = "root"
 	test    = "test"
 	yes     = true
@@ -142,7 +142,7 @@ ExecStart=/usr/bin/sleep infinity
 	}
 
 	// #nosec
-	return os.WriteFile(ignitionFile, contents, 0644)
+	return os.WriteFile(ignitionFile, contents, 0o644)
 }
 
 func dir(path string) Directory {

--- a/test-utils/pull.go
+++ b/test-utils/pull.go
@@ -64,7 +64,7 @@ func Decompress(localPath string) (string, error) {
 	// we remove the uncompressed file if already exists. Maybe it has been used earlier and can affect the tests result
 	os.Remove(uncompressedPath)
 
-	uncompressedFileWriter, err := os.OpenFile(uncompressedPath, os.O_CREATE|os.O_RDWR, 0600)
+	uncompressedFileWriter, err := os.OpenFile(uncompressedPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return "", err
 	}

--- a/test-win-sshproxy/suite_test.go
+++ b/test-win-sshproxy/suite_test.go
@@ -37,9 +37,9 @@ func TestSuite(t *testing.T) {
 func init() {
 	flag.StringVar(&tmpDir, "tmpDir", "../tmp", "temporary working directory")
 	flag.StringVar(&binDir, "bin", "../bin", "directory with compiled binaries")
-	_ = os.MkdirAll(tmpDir, 0755)
+	_ = os.MkdirAll(tmpDir, 0o755)
 	keyFile = filepath.Join(tmpDir, "id.key")
-	_ = os.WriteFile(keyFile, []byte(fakeHostKey), 0600)
+	_ = os.WriteFile(keyFile, []byte(fakeHostKey), 0o600)
 	winSshProxy = filepath.Join(binDir, "win-sshproxy.exe")
 	tidFile = filepath.Join(tmpDir, "win-sshproxy.tid")
 }


### PR DESCRIPTION
Don't stop execution when `win-sshproxy` can't write to the Windows event log.

Also use the strict octal prefix as [gofumpt was complaining](https://github.com/mvdan/gofumpt#Added-rules).

Fixes https://github.com/containers/gvisor-tap-vsock/issues/629