### PR TITLE
forwarder: redact sensitive fields in /all endpoint response (RHDESK-787)

### DIFF
--- a/pkg/services/forwarder/ports.go
+++ b/pkg/services/forwarder/ports.go
@@ -25,6 +25,8 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 )
 
+var redactedParams = []string{"key", "passphrase"}
+
 type ProxyKey string
 
 type PortsForwarder struct {
@@ -284,6 +286,24 @@ func (f *PortsForwarder) Unexpose(protocol types.TransportProtocol, local string
 	return proxy.underlying.Close()
 }
 
+func redactSSHTunnelURI(remote string) string {
+	parsed, err := url.Parse(remote)
+	if err != nil || parsed.Scheme != "ssh-tunnel" {
+		return remote
+	}
+	if parsed.Path != "" {
+		parsed.Path = "***"
+	}
+	query := parsed.Query()
+	for _, param := range redactedParams {
+		if query.Has(param) {
+			query.Set(param, "***")
+		}
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
 func (f *PortsForwarder) Mux() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/all", func(w http.ResponseWriter, _ *http.Request) {
@@ -291,6 +311,7 @@ func (f *PortsForwarder) Mux() http.Handler {
 		defer f.proxiesLock.Unlock()
 		ret := make([]proxy, 0)
 		for _, proxy := range f.proxies {
+			proxy.Remote = redactSSHTunnelURI(proxy.Remote)
 			ret = append(ret, proxy)
 		}
 		sort.Slice(ret, func(i, j int) bool {

--- a/pkg/services/forwarder/ports_test.go
+++ b/pkg/services/forwarder/ports_test.go
@@ -83,6 +83,47 @@ func freeHostAddr(network string, ip net.IP) string {
 	}
 }
 
+var _ = ginkgo.Describe("remote URI redaction", func() {
+	ginkgo.It("should redact key parameter in ssh-tunnel URI", func() {
+		uri := "ssh-tunnel://core@192.168.127.2:22/run/podman/podman.sock?key=/Users/dev/.ssh/id_rsa"
+		result := redactSSHTunnelURI(uri)
+		gomega.Expect(result).To(gomega.ContainSubstring("key=%2A%2A%2A"))
+		gomega.Expect(result).ToNot(gomega.ContainSubstring("id_rsa"))
+	})
+
+	ginkgo.It("should redact passphrase parameter in ssh-tunnel URI", func() {
+		uri := "ssh-tunnel://core@192.168.127.2:22/run/podman/podman.sock?key=/path/to/key&passphrase=supersecret"
+		result := redactSSHTunnelURI(uri)
+		gomega.Expect(result).To(gomega.ContainSubstring("key=%2A%2A%2A"))
+		gomega.Expect(result).To(gomega.ContainSubstring("passphrase=%2A%2A%2A"))
+		gomega.Expect(result).ToNot(gomega.ContainSubstring("supersecret"))
+		gomega.Expect(result).ToNot(gomega.ContainSubstring("/path/to/key"))
+	})
+
+	ginkgo.It("should redact socket path in ssh-tunnel URI", func() {
+		uri := "ssh-tunnel://core@192.168.127.2:22/run/podman/podman.sock?key=/path/to/key"
+		result := redactSSHTunnelURI(uri)
+		gomega.Expect(result).ToNot(gomega.ContainSubstring("podman.sock"))
+	})
+
+	ginkgo.It("should preserve scheme and host in ssh-tunnel URI", func() {
+		uri := "ssh-tunnel://core@192.168.127.2:22/run/podman/podman.sock?key=/path/to/key"
+		result := redactSSHTunnelURI(uri)
+		gomega.Expect(result).To(gomega.ContainSubstring("ssh-tunnel://"))
+		gomega.Expect(result).To(gomega.ContainSubstring("core@192.168.127.2:22"))
+	})
+
+	ginkgo.It("should not modify tcp URIs", func() {
+		uri := "tcp://192.168.127.2:8080"
+		gomega.Expect(redactSSHTunnelURI(uri)).To(gomega.Equal(uri))
+	})
+
+	ginkgo.It("should not modify plain host:port strings", func() {
+		uri := "192.168.127.2:8080"
+		gomega.Expect(redactSSHTunnelURI(uri)).To(gomega.Equal(uri))
+	})
+})
+
 var _ = ginkgo.Describe("source IP propagation", func() {
 	ginkgo.It("should propagate routable IPv4 source addresses", func() {
 		bindAddr := sourceBindAddr(net.ParseIP("10.0.2.50"), 1234)


### PR DESCRIPTION
The /services/forwarder/all endpoint returned the full remote URI including SSH private key paths, passphrases, and internal socket paths in plaintext. This information was accessible from inside any container via the gateway API without authentication.

Redact sensitive fields in ssh-tunnel:// URIs before returning them in the /all response. The key and passphrase query parameters and the socket path are replaced with "***". The scheme, username, and host are preserved for debugging purposes.