### PR TITLE
gvproxy: block /unexpose on gateway API by default (RHDESK-788)

### DIFF
--- a/cmd/gvproxy/config.go
+++ b/cmd/gvproxy/config.go
@@ -24,30 +24,31 @@ const (
 )
 
 type GvproxyArgs struct {
-	config             string
-	endpoints          arrayFlags
-	debug              bool
-	mtu                int
-	sshPort            int
-	subnet             string
-	gatewayIP          string
-	deviceIP           string
-	hostIP             string
-	vpnkitSocket       string
-	qemuSocket         string
-	bessSocket         string
-	stdioSocket        string
-	vfkitSocket        string
-	notificationSocket string
-	forwardSocket      arrayFlags
-	forwardDest        arrayFlags
-	forwardUser        arrayFlags
-	forwardIdentify    arrayFlags
-	pidFile            string
-	pcapFile           string
-	logFile            string
-	servicesEndpoint   string
-	ec2MetadataAccess  bool
+	config               string
+	endpoints            arrayFlags
+	debug                bool
+	mtu                  int
+	sshPort              int
+	subnet               string
+	gatewayIP            string
+	deviceIP             string
+	hostIP               string
+	vpnkitSocket         string
+	qemuSocket           string
+	bessSocket           string
+	stdioSocket          string
+	vfkitSocket          string
+	notificationSocket   string
+	forwardSocket        arrayFlags
+	forwardDest          arrayFlags
+	forwardUser          arrayFlags
+	forwardIdentify      arrayFlags
+	pidFile              string
+	pcapFile             string
+	logFile              string
+	servicesEndpoint     string
+	ec2MetadataAccess    bool
+	gatewayAllowUnexpose bool
 }
 
 type GvproxyConfig struct {
@@ -61,12 +62,13 @@ type GvproxyConfig struct {
 		Stdio  string `yaml:"stdio,omitempty"`
 		Vfkit  string `yaml:"vfkit,omitempty"`
 	} `yaml:"interfaces,omitempty"`
-	Forwards           []GvproxyConfigForward `yaml:"forwards,omitempty"`
-	PIDFile            string                 `yaml:"pid-file,omitempty"`
-	LogFile            string                 `yaml:"log-file,omitempty"`
-	Services           string                 `yaml:"services,omitempty"`
-	Ec2MetadataAccess  bool                   `yaml:"ec2-metadata-access,omitempty"`
-	NotificationSocket string                 `yaml:"notification,omitempty"`
+	Forwards             []GvproxyConfigForward `yaml:"forwards,omitempty"`
+	PIDFile              string                 `yaml:"pid-file,omitempty"`
+	LogFile              string                 `yaml:"log-file,omitempty"`
+	Services             string                 `yaml:"services,omitempty"`
+	Ec2MetadataAccess    bool                   `yaml:"ec2-metadata-access,omitempty"`
+	NotificationSocket   string                 `yaml:"notification,omitempty"`
+	GatewayAllowUnexpose bool                   `yaml:"gateway-allow-unexpose,omitempty"`
 }
 
 type GvproxyConfigForward struct {
@@ -139,6 +141,7 @@ func GvproxyArgParse(flagSet *flag.FlagSet, args *GvproxyArgs, argv []string) (*
 	flagSet.StringVar(&args.servicesEndpoint, "services", "", "Exposes the same HTTP API as the --listen flag, without the /connect endpoint")
 	flagSet.BoolVar(&args.ec2MetadataAccess, "ec2-metadata-access", false, "Permits access to EC2 Metadata Service and Amazon Time Sync Service")
 	flagSet.StringVar(&args.notificationSocket, "notification", "", "Socket to be used to send network-ready notifications")
+	flagSet.BoolVar(&args.gatewayAllowUnexpose, "gateway-allow-unexpose", false, "Allow /unexpose on the gateway API. By default, only /expose and /all are available")
 	if err := flagSet.Parse(argv); err != nil {
 		return nil, err
 	}
@@ -303,6 +306,9 @@ func GvproxyConfigure(config *GvproxyConfig, args *GvproxyArgs, version string) 
 	}
 	if args.ec2MetadataAccess {
 		config.Ec2MetadataAccess = true
+	}
+	if args.gatewayAllowUnexpose {
+		config.GatewayAllowUnexpose = true
 	}
 	if args.mtu != 0 {
 		config.Stack.MTU = args.mtu

--- a/cmd/gvproxy/main.go
+++ b/cmd/gvproxy/main.go
@@ -164,7 +164,9 @@ func run(ctx context.Context, g *errgroup.Group, config *GvproxyConfig) error {
 	mux := http.NewServeMux()
 	mux.Handle("/services/forwarder/all", vn.Mux())
 	mux.Handle("/services/forwarder/expose", vn.Mux())
-	mux.Handle("/services/forwarder/unexpose", vn.Mux())
+	if config.GatewayAllowUnexpose {
+		mux.Handle("/services/forwarder/unexpose", vn.Mux())
+	}
 	httpServe(ctx, g, ln, mux)
 
 	if InDebugMode() {

--- a/pkg/types/gvproxy_command.go
+++ b/pkg/types/gvproxy_command.go
@@ -33,6 +33,9 @@ type GvproxyCommand struct {
 
 	// SSHPort to access the guest VM
 	SSHPort int
+
+	// GatewayAllowUnexpose allows /unexpose on the gateway API
+	GatewayAllowUnexpose bool
 }
 
 func NewGvproxyCommand() GvproxyCommand {
@@ -210,6 +213,11 @@ func (c *GvproxyCommand) ToCmdline() []string {
 	// log-file
 	if c.LogFile != "" {
 		args = append(args, "-log-file", c.LogFile)
+	}
+
+	// gateway-allow-unexpose
+	if c.GatewayAllowUnexpose {
+		args = append(args, "-gateway-allow-unexpose")
 	}
 
 	return args

--- a/test-qemu/suite_test.go
+++ b/test-qemu/suite_test.go
@@ -65,6 +65,9 @@ func gvproxyCmd() *exec.Cmd {
 	cmd := types.NewGvproxyCommand()
 	cmd.AddEndpoint(fmt.Sprintf("unix://%s", sock))
 	cmd.AddQemuSocket("tcp://" + net.JoinHostPort("127.0.0.1", strconv.Itoa(qemuPort)))
+	// Required for tests that call /unexpose from inside the VM via the gateway.
+	// By default, /unexpose is blocked on the gateway API.
+	cmd.GatewayAllowUnexpose = true
 	cmd.AddForwardSock(forwardSock)
 	cmd.AddForwardDest(podmanSock)
 	cmd.AddForwardUser(ignitionUser)


### PR DESCRIPTION
Remove /services/forwarder/unexpose from the gateway API by default to prevent tunnel hijacking attacks from inside the VM. A malicious container could enumerate existing tunnels via /all, tear them down via /unexpose, and re-create them pointing to an attacker-controlled destination via /expose — a Man-in-the-Middle attack requiring no special privileges.

A new --gateway-allow-unexpose flag re-enables the old behavior for users who need it.

With /unexpose blocked, containers can still list and create port forwards but cannot tear down existing ones. Host-side tools that manage port forwards via the Unix socket API are not affected.